### PR TITLE
fixed some bugs

### DIFF
--- a/example_mods/data/trapped/trapped-hard.json
+++ b/example_mods/data/trapped/trapped-hard.json
@@ -1,7 +1,9651 @@
 {
 	"song": {
 		"player1": "brooketrappednew",
-		"player2": "salvage",
+		"gfVersion": "gf",
+		"notes": [
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 150
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 150
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						10666.6666666667,
+						0,
+						1583.33333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						12333.3333333333,
+						2,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						13333.3333333333,
+						1,
+						916.666666666667
+					],
+					[
+						14333.3333333333,
+						3,
+						1583.33333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						16000,
+						2,
+						916.666666666667
+					],
+					[
+						17000,
+						0,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						18000,
+						3,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						18666.6666666667,
+						1,
+						1250
+					],
+					[
+						18666.6666666667,
+						5,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						20000,
+						2,
+						1250
+					],
+					[
+						20000,
+						4,
+						416.666666666667
+					],
+					[
+						20500,
+						6,
+						416.666666666667
+					],
+					[
+						21000,
+						5,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						21333.3333333333,
+						0,
+						1583.33333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						23000,
+						2,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						24000,
+						1,
+						916.666666666667
+					],
+					[
+						25000,
+						3,
+						1583.33333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						26666.6666666667,
+						2,
+						916.666666666667
+					],
+					[
+						27666.6666666667,
+						0,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						28666.6666666667,
+						3,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						29333.3333333333,
+						1,
+						916.666666666667
+					],
+					[
+						30333.3333333333,
+						3,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						31000,
+						2,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						32000,
+						0,
+						1416.66666666667
+					],
+					[
+						32000,
+						1,
+						2416.66666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						34666.6666666667,
+						3,
+						0
+					],
+					[
+						34833.3333333333,
+						1,
+						0
+					],
+					[
+						35166.6666666667,
+						2,
+						250
+					],
+					[
+						35500,
+						0,
+						0
+					],
+					[
+						35666.6666666667,
+						2,
+						0
+					],
+					[
+						35833.3333333333,
+						1,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": true,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						36000,
+						1,
+						0
+					],
+					[
+						36166.6666666667,
+						3,
+						250
+					],
+					[
+						36500,
+						0,
+						0
+					],
+					[
+						36666.6666666667,
+						1,
+						0
+					],
+					[
+						37000,
+						3,
+						250
+					],
+					[
+						36666.6666666667,
+						2,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": true,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						37333.3333333333,
+						6,
+						750
+					],
+					[
+						37333.3333333333,
+						4,
+						2583.33333333333
+					],
+					[
+						37333.3333333333,
+						1,
+						0
+					],
+					[
+						37500,
+						0,
+						0
+					],
+					[
+						37583.3333333333,
+						3,
+						0
+					],
+					[
+						37666.6666666667,
+						0,
+						0
+					],
+					[
+						37750,
+						2,
+						0
+					],
+					[
+						37833.3333333333,
+						1,
+						250
+					],
+					[
+						38166.6666666667,
+						3,
+						0
+					],
+					[
+						38333.3333333333,
+						2,
+						0
+					],
+					[
+						38500,
+						0,
+						250
+					],
+					[
+						38250,
+						0,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": true,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						38833.3333333333,
+						1,
+						250
+					],
+					[
+						39166.6666666667,
+						3,
+						0
+					],
+					[
+						39333.3333333333,
+						2,
+						250
+					],
+					[
+						39666.6666666667,
+						0,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": true,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						40000,
+						1,
+						250
+					],
+					[
+						40333.3333333333,
+						3,
+						0
+					],
+					[
+						40416.6666666667,
+						0,
+						0
+					],
+					[
+						40500,
+						2,
+						416.666666666667
+					],
+					[
+						41000,
+						1,
+						916.666666666667
+					],
+					[
+						41000,
+						0,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": true,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						42000,
+						3,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": true,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						42666.6666666667,
+						2,
+						1250
+					],
+					[
+						42666.6666666667,
+						0,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						44000,
+						1,
+						958.333333333333
+					],
+					[
+						45000,
+						3,
+						125
+					],
+					[
+						45166.6666666667,
+						2,
+						83.3333333333333
+					],
+					[
+						44666.6666666667,
+						4,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						45333.3333333333,
+						4,
+						916.666666666667
+					],
+					[
+						46333.3333333333,
+						5,
+						916.666666666667
+					],
+					[
+						45333.3333333333,
+						2,
+						916.666666666667
+					],
+					[
+						46333.3333333333,
+						1,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						47333.3333333333,
+						7,
+						583.333333333333
+					],
+					[
+						47333.3333333333,
+						3,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						48000,
+						4,
+						1916.66666666667
+					],
+					[
+						48000,
+						2,
+						1916.66666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						50000,
+						1,
+						583.333333333333
+					],
+					[
+						50000,
+						6,
+						500
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						50666.6666666667,
+						4,
+						916.666666666667
+					],
+					[
+						50666.6666666667,
+						1,
+						916.666666666667
+					],
+					[
+						51666.6666666667,
+						3,
+						916.666666666667
+					],
+					[
+						51666.6666666667,
+						6,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						52666.6666666667,
+						7,
+						583.333333333333
+					],
+					[
+						52666.6666666667,
+						0,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						53333.3333333334,
+						2,
+						1250
+					],
+					[
+						53333.3333333334,
+						7,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						54666.6666666667,
+						0,
+						0
+					],
+					[
+						54833.3333333334,
+						3,
+						0
+					],
+					[
+						55166.6666666667,
+						0,
+						0
+					],
+					[
+						55666.6666666667,
+						2,
+						250
+					],
+					[
+						55500,
+						3,
+						0
+					],
+					[
+						55583.3333333334,
+						1,
+						0
+					],
+					[
+						54666.6666666667,
+						5,
+						0
+					],
+					[
+						54833.3333333334,
+						6,
+						0
+					],
+					[
+						55166.6666666667,
+						5,
+						0
+					],
+					[
+						55500,
+						6,
+						0
+					],
+					[
+						55583.3333333334,
+						5,
+						0
+					],
+					[
+						55666.6666666667,
+						7,
+						0
+					],
+					[
+						55750,
+						5,
+						0
+					],
+					[
+						55833.3333333334,
+						6,
+						0
+					],
+					[
+						55916.6666666667,
+						4,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						56000,
+						1,
+						416.666666666667
+					],
+					[
+						56500,
+						3,
+						416.666666666667
+					],
+					[
+						57000,
+						2,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						58000,
+						0,
+						250
+					],
+					[
+						58333.3333333334,
+						2,
+						0
+					],
+					[
+						58500,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						58666.6666666667,
+						3,
+						416.666666666667
+					],
+					[
+						59166.6666666667,
+						1,
+						333.333333333333
+					],
+					[
+						59666.6666666667,
+						2,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						60666.6666666667,
+						1,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						61333.3333333334,
+						0,
+						916.666666666667
+					],
+					[
+						62333.3333333334,
+						3,
+						583.333333333333
+					],
+					[
+						62333.3333333334,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						63000,
+						1,
+						0
+					],
+					[
+						63333.3333333334,
+						1,
+						0
+					],
+					[
+						63500,
+						1,
+						0
+					],
+					[
+						63666.6666666667,
+						1,
+						0
+					],
+					[
+						63750,
+						3,
+						0
+					],
+					[
+						63833.3333333334,
+						0,
+						0
+					],
+					[
+						63916.6666666667,
+						1,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						64000,
+						2,
+						916.666666666667
+					],
+					[
+						65000,
+						3,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						66000,
+						1,
+						291.666666666667
+					],
+					[
+						66333.3333333334,
+						0,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						66666.6666666667,
+						1,
+						250
+					],
+					[
+						67166.6666666667,
+						3,
+						416.666666666667
+					],
+					[
+						67000,
+						0,
+						0
+					],
+					[
+						67666.6666666667,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						68000,
+						2,
+						0
+					],
+					[
+						68166.6666666667,
+						2,
+						0
+					],
+					[
+						68333.3333333334,
+						2,
+						0
+					],
+					[
+						68416.6666666667,
+						0,
+						0
+					],
+					[
+						68500,
+						3,
+						0
+					],
+					[
+						68666.6666666667,
+						3,
+						208.333333333333
+					],
+					[
+						69000,
+						1,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						69333.3333333334,
+						3,
+						375
+					],
+					[
+						69833.3333333334,
+						1,
+						333.333333333333
+					],
+					[
+						70333.3333333334,
+						2,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						71333.3333333334,
+						0,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						72000,
+						3,
+						916.666666666667
+					],
+					[
+						72000,
+						2,
+						250
+					],
+					[
+						73000,
+						0,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						73666.6666666667,
+						1,
+						0
+					],
+					[
+						74000,
+						1,
+						0
+					],
+					[
+						74166.6666666667,
+						1,
+						0
+					],
+					[
+						74333.3333333334,
+						1,
+						0
+					],
+					[
+						74416.6666666667,
+						3,
+						0
+					],
+					[
+						74500,
+						0,
+						0
+					],
+					[
+						74583.3333333334,
+						1,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						74666.6666666667,
+						2,
+						916.666666666667
+					],
+					[
+						75666.6666666667,
+						3,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						76666.6666666667,
+						1,
+						291.666666666667
+					],
+					[
+						77000,
+						0,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						77333.3333333333,
+						3,
+						0
+					],
+					[
+						77500,
+						3,
+						0
+					],
+					[
+						77750,
+						0,
+						0
+					],
+					[
+						77833.3333333333,
+						3,
+						0
+					],
+					[
+						77666.6666666667,
+						3,
+						0
+					],
+					[
+						78000,
+						3,
+						0
+					],
+					[
+						78166.6666666667,
+						1,
+						0
+					],
+					[
+						78250,
+						2,
+						0
+					],
+					[
+						78333.3333333333,
+						3,
+						0
+					],
+					[
+						78500,
+						0,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						78666.6666666667,
+						1,
+						0
+					],
+					[
+						78833.3333333333,
+						1,
+						0
+					],
+					[
+						79000,
+						2,
+						0
+					],
+					[
+						79166.6666666667,
+						3,
+						0
+					],
+					[
+						79333.3333333333,
+						2,
+						250
+					],
+					[
+						79666.6666666667,
+						0,
+						250
+					],
+					[
+						79666.6666666667,
+						1,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						80000,
+						2,
+						0
+					],
+					[
+						80166.6666666667,
+						2,
+						0
+					],
+					[
+						80333.3333333333,
+						0,
+						0
+					],
+					[
+						80416.6666666667,
+						3,
+						0
+					],
+					[
+						80500,
+						2,
+						0
+					],
+					[
+						80666.6666666667,
+						1,
+						250
+					],
+					[
+						81000,
+						0,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						81333.3333333333,
+						3,
+						250
+					],
+					[
+						82333.3333333333,
+						1,
+						0
+					],
+					[
+						82500,
+						2,
+						416.666666666667
+					],
+					[
+						81666.6666666667,
+						0,
+						0
+					],
+					[
+						81750,
+						3,
+						0
+					],
+					[
+						81833.3333333333,
+						0,
+						0
+					],
+					[
+						82000,
+						3,
+						250
+					],
+					[
+						81916.6666666667,
+						1,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						83000,
+						0,
+						0
+					],
+					[
+						83166.6666666667,
+						3,
+						0
+					],
+					[
+						83333.3333333333,
+						2,
+						0
+					],
+					[
+						83500,
+						3,
+						0
+					],
+					[
+						83583.3333333333,
+						1,
+						0
+					],
+					[
+						83666.6666666667,
+						2,
+						0
+					],
+					[
+						83833.3333333333,
+						2,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						84500,
+						0,
+						208.333333333333
+					],
+					[
+						84750,
+						1,
+						166.666666666667
+					],
+					[
+						85000,
+						2,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						85333.3333333333,
+						3,
+						416.666666666667
+					],
+					[
+						85833.3333333333,
+						1,
+						416.666666666667
+					],
+					[
+						86333.3333333333,
+						2,
+						1583.33333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						88166.6666666666,
+						1,
+						0
+					],
+					[
+						88666.6666666666,
+						3,
+						0
+					],
+					[
+						88833.3333333333,
+						3,
+						0
+					],
+					[
+						89166.6666666666,
+						3,
+						0
+					],
+					[
+						88000,
+						4,
+						0
+					],
+					[
+						88166.6666666666,
+						5,
+						0
+					],
+					[
+						88333.3333333333,
+						7,
+						0
+					],
+					[
+						88500,
+						5,
+						0
+					],
+					[
+						88666.6666666666,
+						6,
+						0
+					],
+					[
+						88833.3333333333,
+						5,
+						0
+					],
+					[
+						89000,
+						4,
+						0
+					],
+					[
+						88250,
+						6,
+						0
+					],
+					[
+						89166.6666666666,
+						5,
+						0
+					],
+					[
+						88000,
+						3,
+						0
+					],
+					[
+						88250,
+						0,
+						0
+					],
+					[
+						88333.3333333333,
+						1,
+						0
+					],
+					[
+						88500,
+						2,
+						0
+					],
+					[
+						89000,
+						0,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						89333.3333333333,
+						7,
+						0
+					],
+					[
+						89500,
+						5,
+						0
+					],
+					[
+						89666.6666666666,
+						7,
+						0
+					],
+					[
+						89833.3333333333,
+						6,
+						0
+					],
+					[
+						90000,
+						4,
+						0
+					],
+					[
+						89916.6666666666,
+						5,
+						0
+					],
+					[
+						90166.6666666666,
+						5,
+						0
+					],
+					[
+						90333.3333333333,
+						7,
+						250
+					],
+					[
+						89333.3333333333,
+						3,
+						0
+					],
+					[
+						89500,
+						1,
+						0
+					],
+					[
+						89666.6666666666,
+						2,
+						0
+					],
+					[
+						89833.3333333333,
+						1,
+						0
+					],
+					[
+						89916.6666666666,
+						0,
+						0
+					],
+					[
+						90000,
+						3,
+						0
+					],
+					[
+						90166.6666666666,
+						1,
+						0
+					],
+					[
+						90333.3333333333,
+						2,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						90666.6666666666,
+						4,
+						0
+					],
+					[
+						90833.3333333333,
+						7,
+						0
+					],
+					[
+						90916.6666666666,
+						4,
+						0
+					],
+					[
+						91000,
+						6,
+						0
+					],
+					[
+						91083.3333333333,
+						5,
+						0
+					],
+					[
+						91166.6666666666,
+						7,
+						0
+					],
+					[
+						91333.3333333333,
+						4,
+						0
+					],
+					[
+						91500,
+						4,
+						0
+					],
+					[
+						91583.3333333333,
+						5,
+						0
+					],
+					[
+						91666.6666666666,
+						7,
+						0
+					],
+					[
+						91833.3333333333,
+						5,
+						0
+					],
+					[
+						90666.6666666666,
+						0,
+						0
+					],
+					[
+						91000,
+						2,
+						0
+					],
+					[
+						91083.3333333333,
+						1,
+						0
+					],
+					[
+						91166.6666666666,
+						0,
+						0
+					],
+					[
+						91500,
+						2,
+						0
+					],
+					[
+						91583.3333333333,
+						1,
+						0
+					],
+					[
+						91666.6666666666,
+						0,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						92000,
+						6,
+						0
+					],
+					[
+						92166.6666666666,
+						5,
+						0
+					],
+					[
+						92333.3333333333,
+						7,
+						0
+					],
+					[
+						92500,
+						7,
+						0
+					],
+					[
+						92583.3333333333,
+						6,
+						0
+					],
+					[
+						92666.6666666666,
+						7,
+						250
+					],
+					[
+						93000,
+						4,
+						250
+					],
+					[
+						92000,
+						2,
+						250
+					],
+					[
+						92333.3333333333,
+						3,
+						250
+					],
+					[
+						92666.6666666666,
+						1,
+						250
+					],
+					[
+						93000,
+						2,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						93333.3333333333,
+						1,
+						1250
+					],
+					[
+						93333.3333333333,
+						7,
+						583.333333333333
+					],
+					[
+						94000,
+						6,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						94666.6666666666,
+						4,
+						583.333333333333
+					],
+					[
+						95333.3333333333,
+						5,
+						250
+					],
+					[
+						95666.6666666666,
+						6,
+						916.666666666667
+					],
+					[
+						94666.6666666666,
+						2,
+						416.666666666667
+					],
+					[
+						95166.6666666666,
+						0,
+						416.666666666667
+					],
+					[
+						95666.6666666666,
+						1,
+						1250
+					],
+					[
+						95666.6666666666,
+						3,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						96666.6666666666,
+						7,
+						250
+					],
+					[
+						96999.9999999999,
+						5,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						97333.3333333333,
+						6,
+						0
+					],
+					[
+						97499.9999999999,
+						6,
+						0
+					],
+					[
+						97666.6666666666,
+						4,
+						0
+					],
+					[
+						97833.3333333333,
+						6,
+						0
+					],
+					[
+						97333.3333333333,
+						3,
+						0
+					],
+					[
+						97499.9999999999,
+						3,
+						0
+					],
+					[
+						97666.6666666666,
+						2,
+						0
+					],
+					[
+						97833.3333333333,
+						3,
+						0
+					],
+					[
+						97999.9999999999,
+						1,
+						250
+					],
+					[
+						98333.3333333333,
+						2,
+						0
+					],
+					[
+						98499.9999999999,
+						0,
+						0
+					],
+					[
+						98499.9999999999,
+						3,
+						0
+					],
+					[
+						97999.9999999999,
+						7,
+						250
+					],
+					[
+						98333.3333333333,
+						5,
+						0
+					],
+					[
+						98499.9999999999,
+						6,
+						0
+					],
+					[
+						98499.9999999999,
+						4,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						98833.3333333333,
+						1,
+						0
+					],
+					[
+						98999.9999999999,
+						3,
+						0
+					],
+					[
+						99166.6666666666,
+						1,
+						0
+					],
+					[
+						99333.3333333333,
+						2,
+						0
+					],
+					[
+						99666.6666666666,
+						0,
+						0
+					],
+					[
+						99749.9999999999,
+						1,
+						0
+					],
+					[
+						99833.3333333333,
+						3,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						99999.9999999999,
+						1,
+						0
+					],
+					[
+						100166.666666667,
+						2,
+						0
+					],
+					[
+						100333.333333333,
+						0,
+						0
+					],
+					[
+						100666.666666667,
+						2,
+						250
+					],
+					[
+						100666.666666667,
+						3,
+						0
+					],
+					[
+						101000,
+						1,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						101500,
+						1,
+						0
+					],
+					[
+						101666.666666667,
+						0,
+						0
+					],
+					[
+						101750,
+						2,
+						0
+					],
+					[
+						101833.333333333,
+						3,
+						0
+					],
+					[
+						102000,
+						1,
+						0
+					],
+					[
+						102333.333333333,
+						2,
+						0
+					],
+					[
+						102500,
+						0,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						102666.666666667,
+						2,
+						0
+					],
+					[
+						102833.333333333,
+						1,
+						0
+					],
+					[
+						103000,
+						3,
+						0
+					],
+					[
+						103166.666666667,
+						3,
+						0
+					],
+					[
+						103333.333333333,
+						2,
+						0
+					],
+					[
+						103500,
+						0,
+						0
+					],
+					[
+						103833.333333333,
+						1,
+						0
+					],
+					[
+						103833.333333333,
+						3,
+						0
+					],
+					[
+						103833.333333333,
+						2,
+						750
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						104666.666666667,
+						1,
+						291.666666666667
+					],
+					[
+						105000,
+						0,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						105333.333333333,
+						2,
+						583.333333333333
+					],
+					[
+						106000,
+						3,
+						250
+					],
+					[
+						106500,
+						3,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						106666.666666667,
+						1,
+						0
+					],
+					[
+						106833.333333333,
+						1,
+						0
+					],
+					[
+						107000,
+						2,
+						0
+					],
+					[
+						107166.666666667,
+						0,
+						0
+					],
+					[
+						107333.333333333,
+						3,
+						0
+					],
+					[
+						107333.333333333,
+						1,
+						0
+					],
+					[
+						107500,
+						2,
+						0
+					],
+					[
+						107833.333333333,
+						0,
+						208.333333333333
+					],
+					[
+						107833.333333333,
+						4,
+						208.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						108166.666666667,
+						2,
+						250
+					],
+					[
+						108500,
+						1,
+						416.666666666667
+					],
+					[
+						109000,
+						3,
+						250
+					],
+					[
+						108166.666666667,
+						7,
+						250
+					],
+					[
+						108500,
+						5,
+						416.666666666667
+					],
+					[
+						109000,
+						6,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						109500,
+						1,
+						0
+					],
+					[
+						109666.666666667,
+						3,
+						0
+					],
+					[
+						109833.333333333,
+						1,
+						0
+					],
+					[
+						110000,
+						2,
+						0
+					],
+					[
+						110333.333333333,
+						0,
+						0
+					],
+					[
+						110416.666666667,
+						1,
+						0
+					],
+					[
+						110500,
+						3,
+						0
+					],
+					[
+						109750,
+						0,
+						0
+					],
+					[
+						109333.333333333,
+						4,
+						1666.66666666667
+					],
+					[
+						109333.333333333,
+						5,
+						416.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						110666.666666667,
+						1,
+						0
+					],
+					[
+						110833.333333333,
+						2,
+						0
+					],
+					[
+						111000,
+						0,
+						0
+					],
+					[
+						111333.333333333,
+						2,
+						250
+					],
+					[
+						111333.333333333,
+						3,
+						0
+					],
+					[
+						111666.666666667,
+						1,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						112166.666666667,
+						1,
+						0
+					],
+					[
+						112333.333333333,
+						0,
+						0
+					],
+					[
+						112416.666666667,
+						2,
+						0
+					],
+					[
+						112500,
+						3,
+						0
+					],
+					[
+						112666.666666667,
+						1,
+						0
+					],
+					[
+						113000,
+						2,
+						0
+					],
+					[
+						113166.666666667,
+						0,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						113333.333333333,
+						2,
+						0
+					],
+					[
+						113500,
+						1,
+						0
+					],
+					[
+						113666.666666667,
+						3,
+						0
+					],
+					[
+						113833.333333333,
+						3,
+						0
+					],
+					[
+						114000,
+						2,
+						0
+					],
+					[
+						114166.666666667,
+						0,
+						0
+					],
+					[
+						114500,
+						1,
+						0
+					],
+					[
+						114500,
+						3,
+						0
+					],
+					[
+						114500,
+						2,
+						750
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						115333.333333333,
+						1,
+						291.666666666667
+					],
+					[
+						115666.666666667,
+						0,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						116000,
+						2,
+						583.333333333333
+					],
+					[
+						116666.666666667,
+						3,
+						250
+					],
+					[
+						117166.666666667,
+						3,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						117333.333333333,
+						1,
+						0
+					],
+					[
+						117500,
+						1,
+						0
+					],
+					[
+						117666.666666667,
+						2,
+						0
+					],
+					[
+						117833.333333333,
+						0,
+						0
+					],
+					[
+						118000,
+						3,
+						0
+					],
+					[
+						118000,
+						1,
+						0
+					],
+					[
+						118166.666666667,
+						2,
+						0
+					],
+					[
+						118500,
+						0,
+						208.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						118833.333333333,
+						2,
+						250
+					],
+					[
+						119166.666666667,
+						1,
+						416.666666666667
+					],
+					[
+						119666.666666667,
+						3,
+						250
+					],
+					[
+						119166.666666667,
+						0,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						120000,
+						2,
+						0
+					],
+					[
+						120166.666666667,
+						2,
+						250
+					],
+					[
+						120500,
+						0,
+						0
+					],
+					[
+						120666.666666667,
+						3,
+						250
+					],
+					[
+						121000,
+						1,
+						0
+					],
+					[
+						120000,
+						4,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						121500,
+						1,
+						0
+					],
+					[
+						121666.666666667,
+						0,
+						0
+					],
+					[
+						121750,
+						2,
+						0
+					],
+					[
+						121833.333333333,
+						3,
+						0
+					],
+					[
+						122000,
+						1,
+						250
+					],
+					[
+						122333.333333333,
+						2,
+						250
+					],
+					[
+						121333.333333333,
+						5,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						122666.666666667,
+						0,
+						250
+					],
+					[
+						123000,
+						3,
+						0
+					],
+					[
+						123166.666666667,
+						1,
+						250
+					],
+					[
+						123500,
+						2,
+						250
+					],
+					[
+						123833.333333333,
+						0,
+						0
+					],
+					[
+						122666.666666667,
+						7,
+						1125
+					],
+					[
+						122666.666666667,
+						6,
+						166.666666666667
+					],
+					[
+						123833.333333333,
+						5,
+						125
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						124000,
+						3,
+						0
+					],
+					[
+						124000,
+						1,
+						0
+					],
+					[
+						124166.666666667,
+						2,
+						250
+					],
+					[
+						124500,
+						0,
+						416.666666666667
+					],
+					[
+						125000,
+						2,
+						250
+					],
+					[
+						124000,
+						6,
+						83.3333333333333
+					],
+					[
+						124166.666666667,
+						4,
+						750
+					],
+					[
+						125000,
+						5,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						125333.333333333,
+						0,
+						0
+					],
+					[
+						125500,
+						2,
+						208.333333333333
+					],
+					[
+						125833.333333333,
+						3,
+						0
+					],
+					[
+						126000,
+						1,
+						250
+					],
+					[
+						126333.333333333,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						126833.333333333,
+						2,
+						0
+					],
+					[
+						127000,
+						1,
+						0
+					],
+					[
+						127083.333333333,
+						3,
+						0
+					],
+					[
+						127166.666666666,
+						2,
+						0
+					],
+					[
+						127333.333333333,
+						0,
+						250
+					],
+					[
+						127666.666666666,
+						3,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						128000,
+						1,
+						208.333333333333
+					],
+					[
+						128333.333333333,
+						2,
+						0
+					],
+					[
+						128500,
+						0,
+						250
+					],
+					[
+						128833.333333333,
+						3,
+						208.333333333333
+					],
+					[
+						129166.666666666,
+						2,
+						166.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						129500,
+						1,
+						208.333333333333
+					],
+					[
+						129833.333333333,
+						3,
+						416.666666666667
+					],
+					[
+						129833.333333333,
+						2,
+						0
+					],
+					[
+						130333.333333333,
+						0,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						130833.333333333,
+						1,
+						0
+					],
+					[
+						131000,
+						0,
+						0
+					],
+					[
+						131166.666666666,
+						1,
+						0
+					],
+					[
+						131333.333333333,
+						3,
+						208.333333333333
+					],
+					[
+						131250,
+						2,
+						0
+					],
+					[
+						131666.666666666,
+						1,
+						0
+					],
+					[
+						131750,
+						0,
+						0
+					],
+					[
+						131833.333333333,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						132166.666666666,
+						3,
+						208.333333333333
+					],
+					[
+						132500,
+						1,
+						250
+					],
+					[
+						132166.666666666,
+						0,
+						0
+					],
+					[
+						132833.333333333,
+						2,
+						0
+					],
+					[
+						133000,
+						0,
+						0
+					],
+					[
+						133166.666666666,
+						3,
+						0
+					],
+					[
+						133166.666666666,
+						1,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						133500,
+						2,
+						0
+					],
+					[
+						133666.666666667,
+						0,
+						0
+					],
+					[
+						133750,
+						3,
+						0
+					],
+					[
+						133833.333333333,
+						1,
+						250
+					],
+					[
+						134166.666666667,
+						2,
+						0
+					],
+					[
+						134250,
+						3,
+						0
+					],
+					[
+						134333.333333333,
+						0,
+						0
+					],
+					[
+						134500,
+						1,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						134666.666666667,
+						3,
+						0
+					],
+					[
+						134750,
+						1,
+						0
+					],
+					[
+						134833.333333333,
+						2,
+						0
+					],
+					[
+						135000,
+						0,
+						0
+					],
+					[
+						135333.333333333,
+						3,
+						208.333333333333
+					],
+					[
+						135666.666666667,
+						1,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						136000,
+						2,
+						916.666666666667
+					],
+					[
+						137000,
+						0,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						138000,
+						2,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						138666.666666667,
+						3,
+						875
+					],
+					[
+						139666.666666667,
+						1,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						140666.666666667,
+						2,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						141333.333333333,
+						4,
+						1250
+					],
+					[
+						141333.333333333,
+						5,
+						0
+					],
+					[
+						141333.333333333,
+						3,
+						0
+					],
+					[
+						141500,
+						1,
+						0
+					],
+					[
+						141666.666666667,
+						2,
+						0
+					],
+					[
+						141833.333333333,
+						1,
+						0
+					],
+					[
+						142000,
+						3,
+						0
+					],
+					[
+						142083.333333333,
+						1,
+						0
+					],
+					[
+						142166.666666667,
+						2,
+						0
+					],
+					[
+						142333.333333333,
+						0,
+						0
+					],
+					[
+						142500,
+						1,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						142666.666666667,
+						7,
+						583.333333333333
+					],
+					[
+						143333.333333333,
+						5,
+						583.333333333333
+					],
+					[
+						142833.333333333,
+						3,
+						0
+					],
+					[
+						142916.666666667,
+						0,
+						0
+					],
+					[
+						143000,
+						2,
+						0
+					],
+					[
+						143166.666666667,
+						1,
+						0
+					],
+					[
+						143333.333333333,
+						3,
+						0
+					],
+					[
+						143500,
+						1,
+						0
+					],
+					[
+						143666.666666667,
+						2,
+						0
+					],
+					[
+						143750,
+						0,
+						0
+					],
+					[
+						143833.333333333,
+						1,
+						0
+					],
+					[
+						143833.333333333,
+						3,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						144000,
+						4,
+						0
+					],
+					[
+						144000,
+						7,
+						0
+					],
+					[
+						144000,
+						6,
+						916.666666666667
+					],
+					[
+						145000,
+						5,
+						250
+					],
+					[
+						144000,
+						2,
+						0
+					],
+					[
+						144166.666666667,
+						3,
+						0
+					],
+					[
+						144333.333333333,
+						1,
+						0
+					],
+					[
+						144500,
+						0,
+						0
+					],
+					[
+						144666.666666667,
+						0,
+						0
+					],
+					[
+						144750,
+						2,
+						0
+					],
+					[
+						144833.333333333,
+						1,
+						0
+					],
+					[
+						144916.666666667,
+						3,
+						0
+					],
+					[
+						145000,
+						0,
+						0
+					],
+					[
+						145166.666666667,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						145333.333333333,
+						4,
+						1250
+					],
+					[
+						145333.333333333,
+						1,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						146666.666666667,
+						7,
+						916.666666666667
+					],
+					[
+						146666.666666667,
+						6,
+						0
+					],
+					[
+						147666.666666667,
+						5,
+						916.666666666667
+					],
+					[
+						146666.666666667,
+						2,
+						0
+					],
+					[
+						146750,
+						3,
+						0
+					],
+					[
+						146833.333333333,
+						0,
+						0
+					],
+					[
+						147166.666666667,
+						2,
+						250
+					],
+					[
+						147500,
+						1,
+						0
+					],
+					[
+						147583.333333333,
+						0,
+						0
+					],
+					[
+						147666.666666667,
+						3,
+						0
+					],
+					[
+						147833.333333333,
+						1,
+						0
+					],
+					[
+						147833.333333333,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						148666.666666667,
+						4,
+						291.666666666667
+					],
+					[
+						149000,
+						5,
+						250
+					],
+					[
+						148166.666666667,
+						0,
+						0
+					],
+					[
+						148333.333333333,
+						1,
+						0
+					],
+					[
+						148500,
+						2,
+						0
+					],
+					[
+						148666.666666667,
+						1,
+						250
+					],
+					[
+						149000,
+						3,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						149333.333333333,
+						6,
+						1250
+					],
+					[
+						149333.333333333,
+						1,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						150666.666666667,
+						4,
+						1250
+					],
+					[
+						150666.666666667,
+						2,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						152000,
+						4,
+						1250
+					],
+					[
+						152000,
+						5,
+						0
+					],
+					[
+						152000,
+						3,
+						0
+					],
+					[
+						152166.666666667,
+						1,
+						0
+					],
+					[
+						152333.333333333,
+						2,
+						0
+					],
+					[
+						152500,
+						1,
+						0
+					],
+					[
+						152666.666666667,
+						3,
+						0
+					],
+					[
+						153000,
+						0,
+						0
+					],
+					[
+						153166.666666667,
+						1,
+						0
+					],
+					[
+						152833.333333333,
+						1,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						153333.333333333,
+						7,
+						583.333333333333
+					],
+					[
+						154000,
+						5,
+						583.333333333333
+					],
+					[
+						153500,
+						3,
+						0
+					],
+					[
+						153583.333333333,
+						0,
+						0
+					],
+					[
+						153666.666666667,
+						2,
+						0
+					],
+					[
+						153833.333333333,
+						1,
+						0
+					],
+					[
+						154000,
+						3,
+						0
+					],
+					[
+						154166.666666667,
+						1,
+						0
+					],
+					[
+						154333.333333333,
+						2,
+						0
+					],
+					[
+						154416.666666667,
+						0,
+						0
+					],
+					[
+						154500,
+						1,
+						0
+					],
+					[
+						154500,
+						3,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						154666.666666667,
+						4,
+						0
+					],
+					[
+						154666.666666667,
+						7,
+						0
+					],
+					[
+						154666.666666667,
+						6,
+						916.666666666667
+					],
+					[
+						155666.666666667,
+						5,
+						250
+					],
+					[
+						154666.666666667,
+						2,
+						0
+					],
+					[
+						154833.333333333,
+						3,
+						0
+					],
+					[
+						155000,
+						1,
+						0
+					],
+					[
+						155166.666666667,
+						0,
+						0
+					],
+					[
+						155416.666666667,
+						2,
+						0
+					],
+					[
+						155500,
+						1,
+						0
+					],
+					[
+						155583.333333333,
+						3,
+						0
+					],
+					[
+						155666.666666667,
+						0,
+						0
+					],
+					[
+						155833.333333333,
+						2,
+						0
+					],
+					[
+						155333.333333333,
+						3,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						156000,
+						4,
+						1250
+					],
+					[
+						156000,
+						1,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						157333.333333333,
+						7,
+						916.666666666667
+					],
+					[
+						157333.333333333,
+						6,
+						0
+					],
+					[
+						158333.333333333,
+						5,
+						916.666666666667
+					],
+					[
+						157333.333333333,
+						2,
+						0
+					],
+					[
+						157416.666666667,
+						3,
+						0
+					],
+					[
+						157500,
+						0,
+						0
+					],
+					[
+						157833.333333333,
+						2,
+						250
+					],
+					[
+						158166.666666667,
+						1,
+						0
+					],
+					[
+						158250,
+						0,
+						0
+					],
+					[
+						158333.333333333,
+						3,
+						0
+					],
+					[
+						158500,
+						1,
+						0
+					],
+					[
+						158500,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						158833.333333333,
+						0,
+						0
+					],
+					[
+						159000,
+						1,
+						0
+					],
+					[
+						159166.666666667,
+						2,
+						0
+					],
+					[
+						159333.333333333,
+						1,
+						250
+					],
+					[
+						159666.666666667,
+						3,
+						250
+					],
+					[
+						159333.333333333,
+						4,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						160000,
+						6,
+						583.333333333333
+					],
+					[
+						160000,
+						1,
+						1250
+					],
+					[
+						160666.666666667,
+						4,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						161333.333333333,
+						6,
+						0
+					],
+					[
+						161500,
+						6,
+						0
+					],
+					[
+						161666.666666667,
+						4,
+						0
+					],
+					[
+						161833.333333333,
+						6,
+						0
+					],
+					[
+						161333.333333333,
+						3,
+						0
+					],
+					[
+						161500,
+						3,
+						0
+					],
+					[
+						161666.666666667,
+						2,
+						0
+					],
+					[
+						161833.333333333,
+						3,
+						0
+					],
+					[
+						162000,
+						1,
+						250
+					],
+					[
+						162333.333333333,
+						2,
+						0
+					],
+					[
+						162500,
+						0,
+						0
+					],
+					[
+						162500,
+						3,
+						0
+					],
+					[
+						162000,
+						7,
+						250
+					],
+					[
+						162333.333333333,
+						5,
+						0
+					],
+					[
+						162500,
+						6,
+						0
+					],
+					[
+						162500,
+						4,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						162833.333333333,
+						1,
+						0
+					],
+					[
+						163000,
+						3,
+						0
+					],
+					[
+						163166.666666667,
+						1,
+						0
+					],
+					[
+						163333.333333333,
+						2,
+						0
+					],
+					[
+						163666.666666667,
+						0,
+						0
+					],
+					[
+						163833.333333333,
+						3,
+						0
+					],
+					[
+						162666.666666667,
+						5,
+						0
+					],
+					[
+						162833.333333333,
+						5,
+						0
+					],
+					[
+						163000,
+						4,
+						0
+					],
+					[
+						163083.333333333,
+						5,
+						0
+					],
+					[
+						163166.666666667,
+						7,
+						0
+					],
+					[
+						163333.333333333,
+						5,
+						0
+					],
+					[
+						163500,
+						6,
+						0
+					],
+					[
+						163666.666666667,
+						4,
+						0
+					],
+					[
+						163833.333333333,
+						6,
+						0
+					],
+					[
+						163833.333333333,
+						7,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						164166.666666667,
+						2,
+						0
+					],
+					[
+						164333.333333333,
+						0,
+						0
+					],
+					[
+						164666.666666667,
+						2,
+						250
+					],
+					[
+						164666.666666667,
+						3,
+						0
+					],
+					[
+						165000,
+						1,
+						250
+					],
+					[
+						164000,
+						0,
+						0
+					],
+					[
+						164000,
+						5,
+						0
+					],
+					[
+						164166.666666667,
+						5,
+						0
+					],
+					[
+						164333.333333333,
+						4,
+						0
+					],
+					[
+						164416.666666667,
+						7,
+						0
+					],
+					[
+						164500,
+						5,
+						0
+					],
+					[
+						164666.666666667,
+						5,
+						0
+					],
+					[
+						164833.333333333,
+						5,
+						0
+					],
+					[
+						165000,
+						7,
+						0
+					],
+					[
+						165166.666666667,
+						6,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						165500,
+						1,
+						0
+					],
+					[
+						165666.666666667,
+						0,
+						0
+					],
+					[
+						165833.333333333,
+						3,
+						0
+					],
+					[
+						166000,
+						1,
+						0
+					],
+					[
+						166333.333333333,
+						2,
+						916.666666666667
+					],
+					[
+						166333.333333333,
+						3,
+						0
+					],
+					[
+						165333.333333333,
+						4,
+						0
+					],
+					[
+						165500,
+						4,
+						0
+					],
+					[
+						165666.666666667,
+						5,
+						0
+					],
+					[
+						165750,
+						7,
+						0
+					],
+					[
+						165833.333333333,
+						4,
+						0
+					],
+					[
+						166000,
+						4,
+						0
+					],
+					[
+						166166.666666667,
+						5,
+						0
+					],
+					[
+						166333.333333333,
+						6,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						167333.333333333,
+						4,
+						583.333333333333
+					],
+					[
+						167333.333333333,
+						0,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						168000,
+						1,
+						916.666666666667
+					],
+					[
+						169000,
+						3,
+						916.666666666667
+					],
+					[
+						168000,
+						7,
+						916.666666666667
+					],
+					[
+						169000,
+						5,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						170000,
+						2,
+						250
+					],
+					[
+						170333.333333333,
+						0,
+						0
+					],
+					[
+						170500,
+						2,
+						0
+					],
+					[
+						170000,
+						4,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						170666.666666667,
+						3,
+						916.666666666667
+					],
+					[
+						171666.666666667,
+						1,
+						0
+					],
+					[
+						171833.333333333,
+						2,
+						0
+					],
+					[
+						170666.666666667,
+						5,
+						916.666666666667
+					],
+					[
+						171666.666666667,
+						6,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						172000,
+						1,
+						0
+					],
+					[
+						172333.333333333,
+						1,
+						0
+					],
+					[
+						172500,
+						3,
+						0
+					],
+					[
+						172666.666666667,
+						0,
+						583.333333333333
+					],
+					[
+						172666.666666667,
+						4,
+						583.333333333333
+					],
+					[
+						173000,
+						5,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						173500,
+						1,
+						0
+					],
+					[
+						173666.666666667,
+						3,
+						0
+					],
+					[
+						173833.333333333,
+						1,
+						0
+					],
+					[
+						174000,
+						2,
+						0
+					],
+					[
+						174333.333333333,
+						0,
+						0
+					],
+					[
+						174500,
+						3,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						174833.333333333,
+						2,
+						0
+					],
+					[
+						175000,
+						0,
+						0
+					],
+					[
+						175333.333333333,
+						2,
+						250
+					],
+					[
+						175333.333333333,
+						3,
+						0
+					],
+					[
+						175666.666666667,
+						1,
+						250
+					],
+					[
+						174666.666666667,
+						0,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						176166.666666667,
+						1,
+						0
+					],
+					[
+						176333.333333333,
+						0,
+						0
+					],
+					[
+						176500,
+						3,
+						0
+					],
+					[
+						176666.666666667,
+						1,
+						0
+					],
+					[
+						177000,
+						2,
+						0
+					],
+					[
+						177166.666666667,
+						2,
+						0
+					],
+					[
+						176166.666666667,
+						4,
+						0
+					],
+					[
+						176333.333333333,
+						5,
+						0
+					],
+					[
+						176500,
+						4,
+						0
+					],
+					[
+						176583.333333333,
+						7,
+						0
+					],
+					[
+						176666.666666667,
+						6,
+						250
+					],
+					[
+						177000,
+						4,
+						0
+					],
+					[
+						177166.666666667,
+						5,
+						0
+					],
+					[
+						177250,
+						4,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						177333.333333333,
+						6,
+						0
+					],
+					[
+						177500,
+						5,
+						0
+					],
+					[
+						177666.666666667,
+						7,
+						0
+					],
+					[
+						177833.333333333,
+						5,
+						0
+					],
+					[
+						177916.666666667,
+						4,
+						0
+					],
+					[
+						178000,
+						6,
+						0
+					],
+					[
+						178166.666666667,
+						5,
+						0
+					],
+					[
+						178500,
+						6,
+						1083.33333333333
+					],
+					[
+						177333.333333333,
+						0,
+						0
+					],
+					[
+						177500,
+						3,
+						0
+					],
+					[
+						177666.666666667,
+						0,
+						0
+					],
+					[
+						177833.333333333,
+						1,
+						0
+					],
+					[
+						178000,
+						2,
+						250
+					],
+					[
+						178333.333333333,
+						3,
+						250
+					],
+					[
+						178333.333333333,
+						1,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						179666.666666667,
+						0,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						180000,
+						3,
+						0
+					],
+					[
+						180083.333333334,
+						1,
+						0
+					],
+					[
+						180166.666666667,
+						3,
+						0
+					],
+					[
+						180250,
+						2,
+						0
+					],
+					[
+						180333.333333334,
+						3,
+						0
+					],
+					[
+						180416.666666667,
+						0,
+						0
+					],
+					[
+						180500,
+						3,
+						0
+					],
+					[
+						180583.333333334,
+						1,
+						0
+					],
+					[
+						180666.666666667,
+						2,
+						0
+					],
+					[
+						180833.333333334,
+						0,
+						0
+					],
+					[
+						181000,
+						1,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						181333.333333334,
+						3,
+						0
+					],
+					[
+						181416.666666667,
+						1,
+						0
+					],
+					[
+						181500,
+						3,
+						0
+					],
+					[
+						181583.333333334,
+						2,
+						0
+					],
+					[
+						181666.666666667,
+						3,
+						0
+					],
+					[
+						181750,
+						0,
+						0
+					],
+					[
+						181833.333333334,
+						3,
+						0
+					],
+					[
+						181916.666666667,
+						1,
+						0
+					],
+					[
+						182333.333333334,
+						1,
+						250
+					],
+					[
+						182000,
+						2,
+						250
+					],
+					[
+						181333.333333334,
+						4,
+						0
+					],
+					[
+						181416.666666667,
+						7,
+						0
+					],
+					[
+						181500,
+						4,
+						0
+					],
+					[
+						181583.333333334,
+						5,
+						0
+					],
+					[
+						181666.666666667,
+						4,
+						0
+					],
+					[
+						181750,
+						6,
+						0
+					],
+					[
+						181833.333333334,
+						4,
+						0
+					],
+					[
+						181916.666666667,
+						5,
+						0
+					],
+					[
+						182000,
+						7,
+						250
+					],
+					[
+						182333.333333334,
+						5,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						182666.666666667,
+						7,
+						0
+					],
+					[
+						182750,
+						5,
+						0
+					],
+					[
+						182833.333333334,
+						4,
+						0
+					],
+					[
+						182916.666666667,
+						5,
+						0
+					],
+					[
+						183000,
+						6,
+						0
+					],
+					[
+						183083.333333334,
+						5,
+						0
+					],
+					[
+						183166.666666667,
+						7,
+						0
+					],
+					[
+						183250,
+						5,
+						0
+					],
+					[
+						183333.333333334,
+						6,
+						250
+					],
+					[
+						183666.666666667,
+						4,
+						250
+					],
+					[
+						182666.666666667,
+						3,
+						0
+					],
+					[
+						182750,
+						0,
+						0
+					],
+					[
+						182833.333333334,
+						3,
+						0
+					],
+					[
+						182916.666666667,
+						1,
+						0
+					],
+					[
+						183000,
+						3,
+						0
+					],
+					[
+						183083.333333334,
+						2,
+						0
+					],
+					[
+						183166.666666667,
+						3,
+						0
+					],
+					[
+						183250,
+						1,
+						0
+					],
+					[
+						183333.333333334,
+						0,
+						250
+					],
+					[
+						183666.666666667,
+						3,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						184000,
+						1,
+						2083.33333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						185333.333333334,
+						0,
+						0
+					],
+					[
+						185500,
+						1,
+						0
+					],
+					[
+						185666.666666667,
+						2,
+						0
+					],
+					[
+						185833.333333334,
+						1,
+						0
+					],
+					[
+						185833.333333334,
+						0,
+						0
+					],
+					[
+						186000,
+						3,
+						0
+					],
+					[
+						186083.333333334,
+						0,
+						0
+					],
+					[
+						186166.666666667,
+						2,
+						0
+					],
+					[
+						186333.333333334,
+						1,
+						0
+					],
+					[
+						186500,
+						3,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						187333.333333334,
+						4,
+						583.333333333333
+					],
+					[
+						187500,
+						3,
+						0
+					],
+					[
+						187666.666666667,
+						2,
+						250
+					],
+					[
+						186833.333333334,
+						1,
+						416.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						188000,
+						5,
+						583.333333333333
+					],
+					[
+						188666.666666667,
+						6,
+						250
+					],
+					[
+						189000,
+						7,
+						250
+					],
+					[
+						188000,
+						0,
+						250
+					],
+					[
+						188333.333333334,
+						2,
+						250
+					],
+					[
+						188333.333333334,
+						1,
+						0
+					],
+					[
+						188666.666666667,
+						3,
+						250
+					],
+					[
+						189000,
+						1,
+						416.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						189333.333333334,
+						5,
+						1750
+					],
+					[
+						190000,
+						3,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						190833.333333334,
+						0,
+						0
+					],
+					[
+						191000,
+						3,
+						0
+					],
+					[
+						191166.666666667,
+						1,
+						0
+					],
+					[
+						191333.333333334,
+						2,
+						0
+					],
+					[
+						191416.666666667,
+						0,
+						0
+					],
+					[
+						191500,
+						1,
+						0
+					],
+					[
+						191666.666666667,
+						3,
+						0
+					],
+					[
+						191833.333333334,
+						2,
+						250
+					],
+					[
+						191833.333333334,
+						1,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						192166.666666667,
+						0,
+						250
+					],
+					[
+						192833.333333334,
+						3,
+						0
+					],
+					[
+						193000,
+						1,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						193333.333333334,
+						2,
+						250
+					],
+					[
+						193666.666666667,
+						0,
+						250
+					],
+					[
+						194000,
+						3,
+						250
+					],
+					[
+						194333.333333334,
+						2,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						194666.666666667,
+						1,
+						0
+					],
+					[
+						194833.333333334,
+						0,
+						0
+					],
+					[
+						195000,
+						3,
+						0
+					],
+					[
+						195083.333333334,
+						1,
+						0
+					],
+					[
+						195166.666666667,
+						2,
+						0
+					],
+					[
+						195333.333333334,
+						0,
+						0
+					],
+					[
+						195500,
+						2,
+						0
+					],
+					[
+						195666.666666667,
+						1,
+						0
+					],
+					[
+						195833.333333334,
+						2,
+						0
+					],
+					[
+						194666.666666667,
+						4,
+						1166.66666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						196000,
+						0,
+						0
+					],
+					[
+						196166.666666667,
+						1,
+						0
+					],
+					[
+						196333.333333334,
+						2,
+						0
+					],
+					[
+						196500,
+						1,
+						0
+					],
+					[
+						196500,
+						0,
+						0
+					],
+					[
+						196666.666666667,
+						3,
+						0
+					],
+					[
+						196750,
+						0,
+						0
+					],
+					[
+						196833.333333334,
+						2,
+						0
+					],
+					[
+						197000,
+						1,
+						0
+					],
+					[
+						197166.666666667,
+						3,
+						250
+					],
+					[
+						196000,
+						7,
+						0
+					],
+					[
+						196166.666666667,
+						5,
+						0
+					],
+					[
+						196333.333333334,
+						6,
+						0
+					],
+					[
+						196500,
+						5,
+						0
+					],
+					[
+						196666.666666667,
+						4,
+						0
+					],
+					[
+						196750,
+						7,
+						0
+					],
+					[
+						196833.333333334,
+						5,
+						0
+					],
+					[
+						197000,
+						6,
+						0
+					],
+					[
+						197166.666666667,
+						4,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						197500,
+						1,
+						333.333333333333
+					],
+					[
+						198166.666666667,
+						3,
+						0
+					],
+					[
+						198333.333333334,
+						2,
+						250
+					],
+					[
+						197500,
+						7,
+						333.333333333333
+					],
+					[
+						198333.333333334,
+						6,
+						250
+					],
+					[
+						198166.666666667,
+						4,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						199333.333333334,
+						6,
+						250
+					],
+					[
+						199666.666666667,
+						7,
+						416.666666666667
+					],
+					[
+						198666.666666667,
+						0,
+						250
+					],
+					[
+						199000,
+						2,
+						250
+					],
+					[
+						199000,
+						1,
+						0
+					],
+					[
+						199333.333333334,
+						3,
+						250
+					],
+					[
+						199666.666666667,
+						1,
+						250
+					],
+					[
+						199000,
+						4,
+						250
+					],
+					[
+						199000,
+						7,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						200666.666666667,
+						3,
+						1083.33333333333
+					],
+					[
+						200000,
+						0,
+						583.333333333333
+					],
+					[
+						200666.666666667,
+						5,
+						250
+					],
+					[
+						200666.666666667,
+						4,
+						166.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						202000,
+						2,
+						0
+					],
+					[
+						202083.333333334,
+						0,
+						0
+					],
+					[
+						202166.666666667,
+						1,
+						0
+					],
+					[
+						202333.333333334,
+						3,
+						0
+					],
+					[
+						202500,
+						2,
+						250
+					],
+					[
+						202500,
+						1,
+						0
+					],
+					[
+						201500,
+						5,
+						0
+					],
+					[
+						201666.666666667,
+						6,
+						0
+					],
+					[
+						201833.333333334,
+						5,
+						0
+					],
+					[
+						202000,
+						7,
+						0
+					],
+					[
+						202083.333333334,
+						5,
+						0
+					],
+					[
+						202166.666666667,
+						6,
+						0
+					],
+					[
+						202333.333333334,
+						4,
+						0
+					],
+					[
+						202500,
+						7,
+						0
+					],
+					[
+						202500,
+						6,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						202833.333333334,
+						0,
+						250
+					],
+					[
+						203500,
+						3,
+						0
+					],
+					[
+						203666.666666667,
+						1,
+						250
+					],
+					[
+						202833.333333334,
+						5,
+						250
+					],
+					[
+						203666.666666667,
+						7,
+						250
+					],
+					[
+						203500,
+						4,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						204000,
+						2,
+						250
+					],
+					[
+						204333.333333334,
+						0,
+						250
+					],
+					[
+						204666.666666667,
+						3,
+						250
+					],
+					[
+						205000,
+						2,
+						250
+					],
+					[
+						204000,
+						6,
+						250
+					],
+					[
+						204333.333333334,
+						5,
+						250
+					],
+					[
+						204666.666666667,
+						4,
+						250
+					],
+					[
+						205000,
+						6,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						205500,
+						1,
+						0
+					],
+					[
+						205666.666666667,
+						3,
+						0
+					],
+					[
+						205833.333333333,
+						1,
+						0
+					],
+					[
+						206000,
+						2,
+						0
+					],
+					[
+						206333.333333333,
+						0,
+						0
+					],
+					[
+						206416.666666667,
+						1,
+						0
+					],
+					[
+						206500,
+						3,
+						0
+					],
+					[
+						205750,
+						0,
+						0
+					],
+					[
+						205333.333333334,
+						5,
+						1000
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						206666.666666667,
+						1,
+						0
+					],
+					[
+						206833.333333333,
+						2,
+						0
+					],
+					[
+						207000,
+						0,
+						0
+					],
+					[
+						207333.333333333,
+						2,
+						250
+					],
+					[
+						207333.333333333,
+						3,
+						0
+					],
+					[
+						207666.666666667,
+						1,
+						250
+					],
+					[
+						206666.666666667,
+						7,
+						583.333333333333
+					],
+					[
+						207333.333333334,
+						4,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						208166.666666667,
+						1,
+						0
+					],
+					[
+						208333.333333333,
+						0,
+						0
+					],
+					[
+						208416.666666667,
+						2,
+						0
+					],
+					[
+						208500,
+						3,
+						0
+					],
+					[
+						208666.666666667,
+						1,
+						0
+					],
+					[
+						209000,
+						2,
+						0
+					],
+					[
+						209166.666666667,
+						0,
+						0
+					],
+					[
+						208833.333333334,
+						3,
+						0
+					],
+					[
+						208916.666666667,
+						1,
+						0
+					],
+					[
+						209083.333333334,
+						3,
+						0
+					],
+					[
+						209250,
+						1,
+						0
+					],
+					[
+						208000,
+						6,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						209333.333333333,
+						2,
+						0
+					],
+					[
+						209500,
+						1,
+						0
+					],
+					[
+						209666.666666667,
+						3,
+						0
+					],
+					[
+						209833.333333333,
+						3,
+						0
+					],
+					[
+						210000,
+						2,
+						250
+					],
+					[
+						210333.333333334,
+						0,
+						250
+					],
+					[
+						209333.333333334,
+						7,
+						1250
+					],
+					[
+						209333.333333334,
+						5,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						210666.666666667,
+						1,
+						0
+					],
+					[
+						210750,
+						3,
+						0
+					],
+					[
+						210833.333333334,
+						0,
+						0
+					],
+					[
+						210916.666666667,
+						1,
+						0
+					],
+					[
+						211000,
+						2,
+						0
+					],
+					[
+						211166.666666667,
+						3,
+						0
+					],
+					[
+						211333.333333334,
+						1,
+						0
+					],
+					[
+						211500,
+						2,
+						0
+					],
+					[
+						211666.666666667,
+						0,
+						0
+					],
+					[
+						211833.333333334,
+						2,
+						0
+					],
+					[
+						210666.666666667,
+						6,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						212000,
+						1,
+						0
+					],
+					[
+						212083.333333334,
+						0,
+						0
+					],
+					[
+						212166.666666667,
+						3,
+						0
+					],
+					[
+						212250,
+						1,
+						0
+					],
+					[
+						212333.333333334,
+						2,
+						0
+					],
+					[
+						212416.666666667,
+						0,
+						0
+					],
+					[
+						212500,
+						1,
+						0
+					],
+					[
+						212666.666666667,
+						3,
+						0
+					],
+					[
+						212833.333333334,
+						2,
+						0
+					],
+					[
+						213000,
+						0,
+						250
+					],
+					[
+						212000,
+						4,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						213333.333333334,
+						1,
+						0
+					],
+					[
+						213500,
+						1,
+						0
+					],
+					[
+						213666.666666667,
+						2,
+						0
+					],
+					[
+						213833.333333334,
+						3,
+						0
+					],
+					[
+						214000,
+						0,
+						0
+					],
+					[
+						214166.666666667,
+						0,
+						0
+					],
+					[
+						214333.333333334,
+						2,
+						0
+					],
+					[
+						214500,
+						1,
+						0
+					],
+					[
+						213333.333333334,
+						5,
+						250
+					],
+					[
+						213666.666666667,
+						6,
+						0
+					],
+					[
+						213833.333333334,
+						5,
+						0
+					],
+					[
+						214000,
+						7,
+						0
+					],
+					[
+						214083.333333334,
+						4,
+						0
+					],
+					[
+						214166.666666667,
+						6,
+						0
+					],
+					[
+						214333.333333334,
+						5,
+						416.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						214666.666666667,
+						3,
+						250
+					],
+					[
+						215000,
+						2,
+						250
+					],
+					[
+						215333.333333334,
+						0,
+						250
+					],
+					[
+						215666.666666667,
+						1,
+						250
+					],
+					[
+						214833.333333334,
+						6,
+						416.666666666667
+					],
+					[
+						214833.333333334,
+						4,
+						0
+					],
+					[
+						215333.333333334,
+						5,
+						250
+					],
+					[
+						215666.666666667,
+						7,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						216166.666666667,
+						1,
+						0
+					],
+					[
+						216333.333333333,
+						3,
+						0
+					],
+					[
+						216500,
+						1,
+						0
+					],
+					[
+						216666.666666667,
+						2,
+						0
+					],
+					[
+						217000,
+						0,
+						0
+					],
+					[
+						217083.333333333,
+						1,
+						0
+					],
+					[
+						217166.666666667,
+						3,
+						0
+					],
+					[
+						216416.666666667,
+						0,
+						0
+					],
+					[
+						216000,
+						7,
+						250
+					],
+					[
+						216333.333333334,
+						6,
+						250
+					],
+					[
+						216666.666666667,
+						4,
+						250
+					],
+					[
+						217000,
+						5,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						217333.333333333,
+						1,
+						0
+					],
+					[
+						217500,
+						2,
+						0
+					],
+					[
+						217666.666666667,
+						0,
+						0
+					],
+					[
+						218000,
+						2,
+						250
+					],
+					[
+						218000,
+						3,
+						0
+					],
+					[
+						218333.333333333,
+						1,
+						250
+					],
+					[
+						217333.333333334,
+						7,
+						583.333333333333
+					],
+					[
+						218000,
+						4,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						218833.333333333,
+						1,
+						0
+					],
+					[
+						219000,
+						0,
+						0
+					],
+					[
+						219083.333333333,
+						2,
+						0
+					],
+					[
+						219166.666666667,
+						3,
+						0
+					],
+					[
+						219333.333333333,
+						1,
+						0
+					],
+					[
+						219666.666666667,
+						2,
+						0
+					],
+					[
+						219833.333333333,
+						0,
+						0
+					],
+					[
+						219500,
+						3,
+						0
+					],
+					[
+						219583.333333334,
+						1,
+						0
+					],
+					[
+						219750,
+						3,
+						0
+					],
+					[
+						219916.666666667,
+						1,
+						0
+					],
+					[
+						218666.666666667,
+						6,
+						1250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						220000,
+						2,
+						0
+					],
+					[
+						220166.666666667,
+						1,
+						0
+					],
+					[
+						220333.333333333,
+						3,
+						0
+					],
+					[
+						220500,
+						3,
+						0
+					],
+					[
+						220666.666666667,
+						2,
+						250
+					],
+					[
+						221000,
+						0,
+						250
+					],
+					[
+						220000,
+						7,
+						1000
+					],
+					[
+						220000,
+						5,
+						0
+					],
+					[
+						221000,
+						4,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						221333.333333334,
+						1,
+						0
+					],
+					[
+						221416.666666667,
+						3,
+						0
+					],
+					[
+						221500,
+						0,
+						0
+					],
+					[
+						221583.333333334,
+						1,
+						0
+					],
+					[
+						221666.666666667,
+						2,
+						0
+					],
+					[
+						221833.333333334,
+						3,
+						0
+					],
+					[
+						222000,
+						1,
+						0
+					],
+					[
+						222166.666666667,
+						2,
+						0
+					],
+					[
+						222333.333333334,
+						0,
+						0
+					],
+					[
+						222500,
+						2,
+						0
+					],
+					[
+						221333.333333334,
+						6,
+						416.666666666667
+					],
+					[
+						221833.333333334,
+						7,
+						416.666666666667
+					],
+					[
+						222333.333333334,
+						5,
+						666.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						222666.666666667,
+						1,
+						0
+					],
+					[
+						222750,
+						0,
+						0
+					],
+					[
+						222833.333333334,
+						3,
+						0
+					],
+					[
+						222916.666666667,
+						1,
+						0
+					],
+					[
+						223000,
+						2,
+						0
+					],
+					[
+						223083.333333334,
+						0,
+						0
+					],
+					[
+						223166.666666667,
+						1,
+						0
+					],
+					[
+						223333.333333334,
+						3,
+						0
+					],
+					[
+						223500,
+						2,
+						0
+					],
+					[
+						223666.666666667,
+						0,
+						250
+					],
+					[
+						223166.666666667,
+						5,
+						0
+					],
+					[
+						223333.333333334,
+						4,
+						0
+					],
+					[
+						223500,
+						7,
+						0
+					],
+					[
+						223750,
+						4,
+						0
+					],
+					[
+						223666.666666667,
+						7,
+						0
+					],
+					[
+						223833.333333334,
+						5,
+						0
+					],
+					[
+						223916.666666667,
+						7,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						224000,
+						1,
+						0
+					],
+					[
+						224166.666666667,
+						1,
+						0
+					],
+					[
+						224333.333333334,
+						2,
+						0
+					],
+					[
+						224500,
+						3,
+						0
+					],
+					[
+						224666.666666667,
+						0,
+						0
+					],
+					[
+						224833.333333334,
+						0,
+						0
+					],
+					[
+						225000,
+						2,
+						0
+					],
+					[
+						225166.666666667,
+						1,
+						0
+					],
+					[
+						224000,
+						6,
+						0
+					],
+					[
+						224166.666666667,
+						5,
+						0
+					],
+					[
+						224250,
+						4,
+						166.666666666667
+					],
+					[
+						224500,
+						5,
+						0
+					],
+					[
+						224583.333333334,
+						7,
+						0
+					],
+					[
+						224666.666666667,
+						6,
+						0
+					],
+					[
+						224750,
+						4,
+						0
+					],
+					[
+						224833.333333334,
+						6,
+						0
+					],
+					[
+						224916.666666667,
+						5,
+						0
+					],
+					[
+						225000,
+						7,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						225333.333333334,
+						3,
+						250
+					],
+					[
+						225666.666666667,
+						2,
+						250
+					],
+					[
+						226000,
+						0,
+						250
+					],
+					[
+						226333.333333334,
+						1,
+						250
+					],
+					[
+						225333.333333334,
+						4,
+						0
+					],
+					[
+						225416.666666667,
+						6,
+						0
+					],
+					[
+						225500,
+						5,
+						166.666666666667
+					],
+					[
+						225750,
+						7,
+						166.666666666667
+					],
+					[
+						226000,
+						6,
+						250
+					],
+					[
+						226333.333333334,
+						4,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						226666.666666667,
+						1,
+						1250
+					],
+					[
+						226666.666666667,
+						4,
+						250
+					],
+					[
+						227000.000000001,
+						7,
+						0
+					],
+					[
+						227500.000000001,
+						7,
+						0
+					],
+					[
+						227666.666666667,
+						5,
+						0
+					],
+					[
+						227833.333333334,
+						7,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						228000.000000001,
+						0,
+						250
+					],
+					[
+						228333.333333334,
+						3,
+						0
+					],
+					[
+						228833.333333334,
+						3,
+						0
+					],
+					[
+						229000.000000001,
+						1,
+						0
+					],
+					[
+						229166.666666667,
+						3,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						229333.333333334,
+						1,
+						250
+					],
+					[
+						229666.666666667,
+						2,
+						250
+					],
+					[
+						230166.666666667,
+						2,
+						0
+					],
+					[
+						230333.333333334,
+						0,
+						0
+					],
+					[
+						230500.000000001,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						230666.666666667,
+						3,
+						250
+					],
+					[
+						231000.000000001,
+						1,
+						250
+					],
+					[
+						231333.333333334,
+						2,
+						250
+					],
+					[
+						231666.666666667,
+						0,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						232000.000000001,
+						3,
+						1916.66666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						234000.000000001,
+						1,
+						0
+					],
+					[
+						234166.666666667,
+						3,
+						0
+					],
+					[
+						234333.333333334,
+						1,
+						0
+					],
+					[
+						234500.000000001,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						234666.666666667,
+						0,
+						1250
+					],
+					[
+						234666.666666667,
+						1,
+						333.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						236000.000000001,
+						3,
+						583.333333333333
+					],
+					[
+						236666.666666667,
+						2,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						237333.333333334,
+						5,
+						1833.33333333333
+					],
+					[
+						237333.333333334,
+						0,
+						250
+					],
+					[
+						237666.666666667,
+						3,
+						0
+					],
+					[
+						238166.666666667,
+						3,
+						0
+					],
+					[
+						238333.333333334,
+						1,
+						0
+					],
+					[
+						238500,
+						3,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						238666.666666667,
+						0,
+						250
+					],
+					[
+						239000.000000001,
+						3,
+						0
+					],
+					[
+						239500.000000001,
+						3,
+						0
+					],
+					[
+						239666.666666667,
+						1,
+						0
+					],
+					[
+						239833.333333334,
+						3,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						240000.000000001,
+						1,
+						250
+					],
+					[
+						240333.333333334,
+						2,
+						250
+					],
+					[
+						240833.333333334,
+						2,
+						0
+					],
+					[
+						241000.000000001,
+						0,
+						0
+					],
+					[
+						241166.666666667,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						241333.333333334,
+						3,
+						250
+					],
+					[
+						241666.666666667,
+						1,
+						250
+					],
+					[
+						242000.000000001,
+						2,
+						250
+					],
+					[
+						242333.333333334,
+						0,
+						250
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						242666.666666667,
+						3,
+						1916.66666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						244666.666666667,
+						1,
+						0
+					],
+					[
+						244833.333333334,
+						3,
+						0
+					],
+					[
+						245000.000000001,
+						1,
+						0
+					],
+					[
+						245166.666666667,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						245333.333333334,
+						0,
+						1250
+					],
+					[
+						245333.333333334,
+						1,
+						333.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						246666.666666667,
+						3,
+						583.333333333333
+					],
+					[
+						247333.333333334,
+						1,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						248000,
+						1,
+						416.666666666667
+					],
+					[
+						249000,
+						2,
+						916.666666666667
+					],
+					[
+						248500.000000001,
+						3,
+						416.666666666667
+					],
+					[
+						248000.000000001,
+						6,
+						1916.66666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						250000,
+						0,
+						250
+					],
+					[
+						250333.333333333,
+						2,
+						0
+					],
+					[
+						250500,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						250666.666666667,
+						3,
+						416.666666666667
+					],
+					[
+						251166.666666667,
+						1,
+						333.333333333333
+					],
+					[
+						251666.666666667,
+						2,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						252666.666666667,
+						1,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						253333.333333333,
+						0,
+						916.666666666667
+					],
+					[
+						254333.333333333,
+						3,
+						583.333333333333
+					],
+					[
+						254333.333333333,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						255000,
+						1,
+						0
+					],
+					[
+						255333.333333333,
+						1,
+						0
+					],
+					[
+						255500,
+						1,
+						0
+					],
+					[
+						255666.666666667,
+						1,
+						0
+					],
+					[
+						255750,
+						3,
+						0
+					],
+					[
+						255833.333333333,
+						0,
+						0
+					],
+					[
+						255916.666666667,
+						1,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						256000,
+						2,
+						916.666666666667
+					],
+					[
+						257000,
+						3,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						258000.000000001,
+						1,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						258666.666666667,
+						1,
+						250
+					],
+					[
+						259166.666666667,
+						3,
+						416.666666666667
+					],
+					[
+						259000,
+						0,
+						0
+					],
+					[
+						258666.666666667,
+						1,
+						250
+					],
+					[
+						259166.666666667,
+						3,
+						416.666666666667
+					],
+					[
+						258666.666666667,
+						6,
+						2500
+					],
+					[
+						259666.666666667,
+						2,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						260666.666666667,
+						0,
+						250
+					],
+					[
+						261000,
+						2,
+						0
+					],
+					[
+						261166.666666667,
+						2,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						261333.333333333,
+						3,
+						250
+					],
+					[
+						261833.333333333,
+						1,
+						416.666666666666
+					],
+					[
+						261666.666666667,
+						1,
+						0
+					],
+					[
+						262333.333333334,
+						2,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						263333.333333333,
+						1,
+						583.333333333333
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": true,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						264000,
+						4,
+						916.666666666667
+					],
+					[
+						265000,
+						7,
+						583.333333333333
+					],
+					[
+						265000,
+						6,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						265666.666666667,
+						5,
+						0
+					],
+					[
+						266000,
+						5,
+						0
+					],
+					[
+						266166.666666667,
+						5,
+						0
+					],
+					[
+						266333.333333333,
+						5,
+						0
+					],
+					[
+						266416.666666667,
+						7,
+						0
+					],
+					[
+						266500,
+						4,
+						0
+					],
+					[
+						266583.333333333,
+						5,
+						0
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						267666.666666667,
+						7,
+						916.666666666667
+					],
+					[
+						266666.666666667,
+						6,
+						916.666666666667
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						268666.666666667,
+						5,
+						583.333333333333,
+						"No Animation"
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [
+					[
+						269333.333333334,
+						4,
+						1666.66666666667,
+						"No Animation"
+					]
+				],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"sectionNotes": [],
+				"typeOfSection": 0,
+				"gfSection": false,
+				"altAnim": false,
+				"mustHitSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"sectionBeats": 4,
+				"altAnim": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"sectionBeats": 4,
+				"altAnim": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"sectionBeats": 4,
+				"altAnim": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"sectionBeats": 4,
+				"altAnim": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"sectionBeats": 4,
+				"altAnim": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"sectionBeats": 4,
+				"altAnim": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"sectionBeats": 4,
+				"altAnim": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"sectionBeats": 4,
+				"altAnim": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"sectionBeats": 4,
+				"altAnim": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"sectionBeats": 4,
+				"altAnim": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"sectionBeats": 4,
+				"altAnim": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"changeBPM": false,
+				"bpm": 180
+			},
+			{
+				"sectionBeats": 4,
+				"altAnim": false,
+				"mustHitSection": true,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"bpm": 180,
+				"changeBPM": false
+			},
+			{
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"altAnim": false,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"bpm": 180,
+				"sectionBeats": 4,
+				"changeBPM": false,
+				"mustHitSection": true
+			},
+			{
+				"pixelNoteSection": false,
+				"gfSection": false,
+				"altAnim": false,
+				"typeOfSection": 0,
+				"sectionNotes": [],
+				"bpm": 180,
+				"sectionBeats": 4,
+				"changeBPM": false,
+				"mustHitSection": true
+			}
+		],
 		"events": [
 			[
 				0,
@@ -1989,9651 +11633,14 @@
 				]
 			]
 		],
-		"notes": [
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 150,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 150,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						10666.6666666667,
-						0,
-						1583.33333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						12333.3333333333,
-						2,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						13333.3333333333,
-						1,
-						916.666666666667
-					],
-					[
-						14333.3333333333,
-						3,
-						1583.33333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						16000,
-						2,
-						916.666666666667
-					],
-					[
-						17000,
-						0,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						18000,
-						3,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						18666.6666666667,
-						1,
-						1250
-					],
-					[
-						18666.6666666667,
-						5,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						20000,
-						2,
-						1250
-					],
-					[
-						20000,
-						4,
-						416.666666666667
-					],
-					[
-						20500,
-						6,
-						416.666666666667
-					],
-					[
-						21000,
-						5,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						21333.3333333333,
-						0,
-						1583.33333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						23000,
-						2,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						24000,
-						1,
-						916.666666666667
-					],
-					[
-						25000,
-						3,
-						1583.33333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						26666.6666666667,
-						2,
-						916.666666666667
-					],
-					[
-						27666.6666666667,
-						0,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						28666.6666666667,
-						3,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						29333.3333333333,
-						1,
-						916.666666666667
-					],
-					[
-						30333.3333333333,
-						3,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						31000,
-						2,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						32000,
-						0,
-						1416.66666666667
-					],
-					[
-						32000,
-						1,
-						2416.66666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						34666.6666666667,
-						3,
-						0
-					],
-					[
-						34833.3333333333,
-						1,
-						0
-					],
-					[
-						35166.6666666667,
-						2,
-						250
-					],
-					[
-						35500,
-						0,
-						0
-					],
-					[
-						35666.6666666667,
-						2,
-						0
-					],
-					[
-						35833.3333333333,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": true,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						36000,
-						1,
-						0
-					],
-					[
-						36166.6666666667,
-						3,
-						250
-					],
-					[
-						36500,
-						0,
-						0
-					],
-					[
-						36666.6666666667,
-						1,
-						0
-					],
-					[
-						37000,
-						3,
-						250
-					],
-					[
-						36666.6666666667,
-						2,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": true,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						37333.3333333333,
-						6,
-						750
-					],
-					[
-						37333.3333333333,
-						4,
-						2583.33333333333
-					],
-					[
-						37333.3333333333,
-						1,
-						0
-					],
-					[
-						37500,
-						0,
-						0
-					],
-					[
-						37583.3333333333,
-						3,
-						0
-					],
-					[
-						37666.6666666667,
-						0,
-						0
-					],
-					[
-						37750,
-						2,
-						0
-					],
-					[
-						37833.3333333333,
-						1,
-						250
-					],
-					[
-						38166.6666666667,
-						3,
-						0
-					],
-					[
-						38333.3333333333,
-						2,
-						0
-					],
-					[
-						38500,
-						0,
-						250
-					],
-					[
-						38250,
-						0,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": true,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						38833.3333333333,
-						1,
-						250
-					],
-					[
-						39166.6666666667,
-						3,
-						0
-					],
-					[
-						39333.3333333333,
-						2,
-						250
-					],
-					[
-						39666.6666666667,
-						0,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": true,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						40000,
-						1,
-						250
-					],
-					[
-						40333.3333333333,
-						3,
-						0
-					],
-					[
-						40416.6666666667,
-						0,
-						0
-					],
-					[
-						40500,
-						2,
-						416.666666666667
-					],
-					[
-						41000,
-						1,
-						916.666666666667
-					],
-					[
-						41000,
-						0,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": true,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						42000,
-						3,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": true,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						42666.6666666667,
-						2,
-						1250
-					],
-					[
-						42666.6666666667,
-						0,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						44000,
-						1,
-						958.333333333333
-					],
-					[
-						45000,
-						3,
-						125
-					],
-					[
-						45166.6666666667,
-						2,
-						83.3333333333333
-					],
-					[
-						44666.6666666667,
-						4,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						45333.3333333333,
-						4,
-						916.666666666667
-					],
-					[
-						46333.3333333333,
-						5,
-						916.666666666667
-					],
-					[
-						45333.3333333333,
-						2,
-						916.666666666667
-					],
-					[
-						46333.3333333333,
-						1,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						47333.3333333333,
-						7,
-						583.333333333333
-					],
-					[
-						47333.3333333333,
-						3,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						48000,
-						4,
-						1916.66666666667
-					],
-					[
-						48000,
-						2,
-						1916.66666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						50000,
-						1,
-						583.333333333333
-					],
-					[
-						50000,
-						6,
-						500
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						50666.6666666667,
-						4,
-						916.666666666667
-					],
-					[
-						50666.6666666667,
-						1,
-						916.666666666667
-					],
-					[
-						51666.6666666667,
-						3,
-						916.666666666667
-					],
-					[
-						51666.6666666667,
-						6,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						52666.6666666667,
-						7,
-						583.333333333333
-					],
-					[
-						52666.6666666667,
-						0,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						53333.3333333334,
-						2,
-						1250
-					],
-					[
-						53333.3333333334,
-						7,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						54666.6666666667,
-						0,
-						0
-					],
-					[
-						54833.3333333334,
-						3,
-						0
-					],
-					[
-						55166.6666666667,
-						0,
-						0
-					],
-					[
-						55666.6666666667,
-						2,
-						250
-					],
-					[
-						55500,
-						3,
-						0
-					],
-					[
-						55583.3333333334,
-						1,
-						0
-					],
-					[
-						54666.6666666667,
-						5,
-						0
-					],
-					[
-						54833.3333333334,
-						6,
-						0
-					],
-					[
-						55166.6666666667,
-						5,
-						0
-					],
-					[
-						55500,
-						6,
-						0
-					],
-					[
-						55583.3333333334,
-						5,
-						0
-					],
-					[
-						55666.6666666667,
-						7,
-						0
-					],
-					[
-						55750,
-						5,
-						0
-					],
-					[
-						55833.3333333334,
-						6,
-						0
-					],
-					[
-						55916.6666666667,
-						4,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						56000,
-						1,
-						416.666666666667
-					],
-					[
-						56500,
-						3,
-						416.666666666667
-					],
-					[
-						57000,
-						2,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						58000,
-						0,
-						250
-					],
-					[
-						58333.3333333334,
-						2,
-						0
-					],
-					[
-						58500,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						58666.6666666667,
-						3,
-						416.666666666667
-					],
-					[
-						59166.6666666667,
-						1,
-						333.333333333333
-					],
-					[
-						59666.6666666667,
-						2,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						60666.6666666667,
-						1,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						61333.3333333334,
-						0,
-						916.666666666667
-					],
-					[
-						62333.3333333334,
-						3,
-						583.333333333333
-					],
-					[
-						62333.3333333334,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						63000,
-						1,
-						0
-					],
-					[
-						63333.3333333334,
-						1,
-						0
-					],
-					[
-						63500,
-						1,
-						0
-					],
-					[
-						63666.6666666667,
-						1,
-						0
-					],
-					[
-						63750,
-						3,
-						0
-					],
-					[
-						63833.3333333334,
-						0,
-						0
-					],
-					[
-						63916.6666666667,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						64000,
-						2,
-						916.666666666667
-					],
-					[
-						65000,
-						3,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						66000,
-						1,
-						291.666666666667
-					],
-					[
-						66333.3333333334,
-						0,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						66666.6666666667,
-						1,
-						250
-					],
-					[
-						67166.6666666667,
-						3,
-						416.666666666667
-					],
-					[
-						67000,
-						0,
-						0
-					],
-					[
-						67666.6666666667,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						68000,
-						2,
-						0
-					],
-					[
-						68166.6666666667,
-						2,
-						0
-					],
-					[
-						68333.3333333334,
-						2,
-						0
-					],
-					[
-						68416.6666666667,
-						0,
-						0
-					],
-					[
-						68500,
-						3,
-						0
-					],
-					[
-						68666.6666666667,
-						3,
-						208.333333333333
-					],
-					[
-						69000,
-						1,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						69333.3333333334,
-						3,
-						375
-					],
-					[
-						69833.3333333334,
-						1,
-						333.333333333333
-					],
-					[
-						70333.3333333334,
-						2,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						71333.3333333334,
-						0,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						72000,
-						3,
-						916.666666666667
-					],
-					[
-						72000,
-						2,
-						250
-					],
-					[
-						73000,
-						0,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						73666.6666666667,
-						1,
-						0
-					],
-					[
-						74000,
-						1,
-						0
-					],
-					[
-						74166.6666666667,
-						1,
-						0
-					],
-					[
-						74333.3333333334,
-						1,
-						0
-					],
-					[
-						74416.6666666667,
-						3,
-						0
-					],
-					[
-						74500,
-						0,
-						0
-					],
-					[
-						74583.3333333334,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						74666.6666666667,
-						2,
-						916.666666666667
-					],
-					[
-						75666.6666666667,
-						3,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						76666.6666666667,
-						1,
-						291.666666666667
-					],
-					[
-						77000,
-						0,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						77333.3333333333,
-						3,
-						0
-					],
-					[
-						77500,
-						3,
-						0
-					],
-					[
-						77750,
-						0,
-						0
-					],
-					[
-						77833.3333333333,
-						3,
-						0
-					],
-					[
-						77666.6666666667,
-						3,
-						0
-					],
-					[
-						78000,
-						3,
-						0
-					],
-					[
-						78166.6666666667,
-						1,
-						0
-					],
-					[
-						78250,
-						2,
-						0
-					],
-					[
-						78333.3333333333,
-						3,
-						0
-					],
-					[
-						78500,
-						0,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						78666.6666666667,
-						1,
-						0
-					],
-					[
-						78833.3333333333,
-						1,
-						0
-					],
-					[
-						79000,
-						2,
-						0
-					],
-					[
-						79166.6666666667,
-						3,
-						0
-					],
-					[
-						79333.3333333333,
-						2,
-						250
-					],
-					[
-						79666.6666666667,
-						0,
-						250
-					],
-					[
-						79666.6666666667,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						80000,
-						2,
-						0
-					],
-					[
-						80166.6666666667,
-						2,
-						0
-					],
-					[
-						80333.3333333333,
-						0,
-						0
-					],
-					[
-						80416.6666666667,
-						3,
-						0
-					],
-					[
-						80500,
-						2,
-						0
-					],
-					[
-						80666.6666666667,
-						1,
-						250
-					],
-					[
-						81000,
-						0,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						81333.3333333333,
-						3,
-						250
-					],
-					[
-						82333.3333333333,
-						1,
-						0
-					],
-					[
-						82500,
-						2,
-						416.666666666667
-					],
-					[
-						81666.6666666667,
-						0,
-						0
-					],
-					[
-						81750,
-						3,
-						0
-					],
-					[
-						81833.3333333333,
-						0,
-						0
-					],
-					[
-						82000,
-						3,
-						250
-					],
-					[
-						81916.6666666667,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						83000,
-						0,
-						0
-					],
-					[
-						83166.6666666667,
-						3,
-						0
-					],
-					[
-						83333.3333333333,
-						2,
-						0
-					],
-					[
-						83500,
-						3,
-						0
-					],
-					[
-						83583.3333333333,
-						1,
-						0
-					],
-					[
-						83666.6666666667,
-						2,
-						0
-					],
-					[
-						83833.3333333333,
-						2,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						84500,
-						0,
-						208.333333333333
-					],
-					[
-						84750,
-						1,
-						166.666666666667
-					],
-					[
-						85000,
-						2,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						85333.3333333333,
-						3,
-						416.666666666667
-					],
-					[
-						85833.3333333333,
-						1,
-						416.666666666667
-					],
-					[
-						86333.3333333333,
-						2,
-						1583.33333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						88166.6666666666,
-						1,
-						0
-					],
-					[
-						88666.6666666666,
-						3,
-						0
-					],
-					[
-						88833.3333333333,
-						3,
-						0
-					],
-					[
-						89166.6666666666,
-						3,
-						0
-					],
-					[
-						88000,
-						4,
-						0
-					],
-					[
-						88166.6666666666,
-						5,
-						0
-					],
-					[
-						88333.3333333333,
-						7,
-						0
-					],
-					[
-						88500,
-						5,
-						0
-					],
-					[
-						88666.6666666666,
-						6,
-						0
-					],
-					[
-						88833.3333333333,
-						5,
-						0
-					],
-					[
-						89000,
-						4,
-						0
-					],
-					[
-						88250,
-						6,
-						0
-					],
-					[
-						89166.6666666666,
-						5,
-						0
-					],
-					[
-						88000,
-						3,
-						0
-					],
-					[
-						88250,
-						0,
-						0
-					],
-					[
-						88333.3333333333,
-						1,
-						0
-					],
-					[
-						88500,
-						2,
-						0
-					],
-					[
-						89000,
-						0,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						89333.3333333333,
-						7,
-						0
-					],
-					[
-						89500,
-						5,
-						0
-					],
-					[
-						89666.6666666666,
-						7,
-						0
-					],
-					[
-						89833.3333333333,
-						6,
-						0
-					],
-					[
-						90000,
-						4,
-						0
-					],
-					[
-						89916.6666666666,
-						5,
-						0
-					],
-					[
-						90166.6666666666,
-						5,
-						0
-					],
-					[
-						90333.3333333333,
-						7,
-						250
-					],
-					[
-						89333.3333333333,
-						3,
-						0
-					],
-					[
-						89500,
-						1,
-						0
-					],
-					[
-						89666.6666666666,
-						2,
-						0
-					],
-					[
-						89833.3333333333,
-						1,
-						0
-					],
-					[
-						89916.6666666666,
-						0,
-						0
-					],
-					[
-						90000,
-						3,
-						0
-					],
-					[
-						90166.6666666666,
-						1,
-						0
-					],
-					[
-						90333.3333333333,
-						2,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						90666.6666666666,
-						4,
-						0
-					],
-					[
-						90833.3333333333,
-						7,
-						0
-					],
-					[
-						90916.6666666666,
-						4,
-						0
-					],
-					[
-						91000,
-						6,
-						0
-					],
-					[
-						91083.3333333333,
-						5,
-						0
-					],
-					[
-						91166.6666666666,
-						7,
-						0
-					],
-					[
-						91333.3333333333,
-						4,
-						0
-					],
-					[
-						91500,
-						4,
-						0
-					],
-					[
-						91583.3333333333,
-						5,
-						0
-					],
-					[
-						91666.6666666666,
-						7,
-						0
-					],
-					[
-						91833.3333333333,
-						5,
-						0
-					],
-					[
-						90666.6666666666,
-						0,
-						0
-					],
-					[
-						91000,
-						2,
-						0
-					],
-					[
-						91083.3333333333,
-						1,
-						0
-					],
-					[
-						91166.6666666666,
-						0,
-						0
-					],
-					[
-						91500,
-						2,
-						0
-					],
-					[
-						91583.3333333333,
-						1,
-						0
-					],
-					[
-						91666.6666666666,
-						0,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						92000,
-						6,
-						0
-					],
-					[
-						92166.6666666666,
-						5,
-						0
-					],
-					[
-						92333.3333333333,
-						7,
-						0
-					],
-					[
-						92500,
-						7,
-						0
-					],
-					[
-						92583.3333333333,
-						6,
-						0
-					],
-					[
-						92666.6666666666,
-						7,
-						250
-					],
-					[
-						93000,
-						4,
-						250
-					],
-					[
-						92000,
-						2,
-						250
-					],
-					[
-						92333.3333333333,
-						3,
-						250
-					],
-					[
-						92666.6666666666,
-						1,
-						250
-					],
-					[
-						93000,
-						2,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						93333.3333333333,
-						1,
-						1250
-					],
-					[
-						93333.3333333333,
-						7,
-						583.333333333333
-					],
-					[
-						94000,
-						6,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						94666.6666666666,
-						4,
-						583.333333333333
-					],
-					[
-						95333.3333333333,
-						5,
-						250
-					],
-					[
-						95666.6666666666,
-						6,
-						916.666666666667
-					],
-					[
-						94666.6666666666,
-						2,
-						416.666666666667
-					],
-					[
-						95166.6666666666,
-						0,
-						416.666666666667
-					],
-					[
-						95666.6666666666,
-						1,
-						1250
-					],
-					[
-						95666.6666666666,
-						3,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						96666.6666666666,
-						7,
-						250
-					],
-					[
-						96999.9999999999,
-						5,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						97333.3333333333,
-						6,
-						0
-					],
-					[
-						97499.9999999999,
-						6,
-						0
-					],
-					[
-						97666.6666666666,
-						4,
-						0
-					],
-					[
-						97833.3333333333,
-						6,
-						0
-					],
-					[
-						97333.3333333333,
-						3,
-						0
-					],
-					[
-						97499.9999999999,
-						3,
-						0
-					],
-					[
-						97666.6666666666,
-						2,
-						0
-					],
-					[
-						97833.3333333333,
-						3,
-						0
-					],
-					[
-						97999.9999999999,
-						1,
-						250
-					],
-					[
-						98333.3333333333,
-						2,
-						0
-					],
-					[
-						98499.9999999999,
-						0,
-						0
-					],
-					[
-						98499.9999999999,
-						3,
-						0
-					],
-					[
-						97999.9999999999,
-						7,
-						250
-					],
-					[
-						98333.3333333333,
-						5,
-						0
-					],
-					[
-						98499.9999999999,
-						6,
-						0
-					],
-					[
-						98499.9999999999,
-						4,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						98833.3333333333,
-						1,
-						0
-					],
-					[
-						98999.9999999999,
-						3,
-						0
-					],
-					[
-						99166.6666666666,
-						1,
-						0
-					],
-					[
-						99333.3333333333,
-						2,
-						0
-					],
-					[
-						99666.6666666666,
-						0,
-						0
-					],
-					[
-						99749.9999999999,
-						1,
-						0
-					],
-					[
-						99833.3333333333,
-						3,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						99999.9999999999,
-						1,
-						0
-					],
-					[
-						100166.666666667,
-						2,
-						0
-					],
-					[
-						100333.333333333,
-						0,
-						0
-					],
-					[
-						100666.666666667,
-						2,
-						250
-					],
-					[
-						100666.666666667,
-						3,
-						0
-					],
-					[
-						101000,
-						1,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						101500,
-						1,
-						0
-					],
-					[
-						101666.666666667,
-						0,
-						0
-					],
-					[
-						101750,
-						2,
-						0
-					],
-					[
-						101833.333333333,
-						3,
-						0
-					],
-					[
-						102000,
-						1,
-						0
-					],
-					[
-						102333.333333333,
-						2,
-						0
-					],
-					[
-						102500,
-						0,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						102666.666666667,
-						2,
-						0
-					],
-					[
-						102833.333333333,
-						1,
-						0
-					],
-					[
-						103000,
-						3,
-						0
-					],
-					[
-						103166.666666667,
-						3,
-						0
-					],
-					[
-						103333.333333333,
-						2,
-						0
-					],
-					[
-						103500,
-						0,
-						0
-					],
-					[
-						103833.333333333,
-						1,
-						0
-					],
-					[
-						103833.333333333,
-						3,
-						0
-					],
-					[
-						103833.333333333,
-						2,
-						750
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						104666.666666667,
-						1,
-						291.666666666667
-					],
-					[
-						105000,
-						0,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						105333.333333333,
-						2,
-						583.333333333333
-					],
-					[
-						106000,
-						3,
-						250
-					],
-					[
-						106500,
-						3,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						106666.666666667,
-						1,
-						0
-					],
-					[
-						106833.333333333,
-						1,
-						0
-					],
-					[
-						107000,
-						2,
-						0
-					],
-					[
-						107166.666666667,
-						0,
-						0
-					],
-					[
-						107333.333333333,
-						3,
-						0
-					],
-					[
-						107333.333333333,
-						1,
-						0
-					],
-					[
-						107500,
-						2,
-						0
-					],
-					[
-						107833.333333333,
-						0,
-						208.333333333333
-					],
-					[
-						107833.333333333,
-						4,
-						208.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						108166.666666667,
-						2,
-						250
-					],
-					[
-						108500,
-						1,
-						416.666666666667
-					],
-					[
-						109000,
-						3,
-						250
-					],
-					[
-						108166.666666667,
-						7,
-						250
-					],
-					[
-						108500,
-						5,
-						416.666666666667
-					],
-					[
-						109000,
-						6,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						109500,
-						1,
-						0
-					],
-					[
-						109666.666666667,
-						3,
-						0
-					],
-					[
-						109833.333333333,
-						1,
-						0
-					],
-					[
-						110000,
-						2,
-						0
-					],
-					[
-						110333.333333333,
-						0,
-						0
-					],
-					[
-						110416.666666667,
-						1,
-						0
-					],
-					[
-						110500,
-						3,
-						0
-					],
-					[
-						109750,
-						0,
-						0
-					],
-					[
-						109333.333333333,
-						4,
-						1666.66666666667
-					],
-					[
-						109333.333333333,
-						5,
-						416.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						110666.666666667,
-						1,
-						0
-					],
-					[
-						110833.333333333,
-						2,
-						0
-					],
-					[
-						111000,
-						0,
-						0
-					],
-					[
-						111333.333333333,
-						2,
-						250
-					],
-					[
-						111333.333333333,
-						3,
-						0
-					],
-					[
-						111666.666666667,
-						1,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						112166.666666667,
-						1,
-						0
-					],
-					[
-						112333.333333333,
-						0,
-						0
-					],
-					[
-						112416.666666667,
-						2,
-						0
-					],
-					[
-						112500,
-						3,
-						0
-					],
-					[
-						112666.666666667,
-						1,
-						0
-					],
-					[
-						113000,
-						2,
-						0
-					],
-					[
-						113166.666666667,
-						0,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						113333.333333333,
-						2,
-						0
-					],
-					[
-						113500,
-						1,
-						0
-					],
-					[
-						113666.666666667,
-						3,
-						0
-					],
-					[
-						113833.333333333,
-						3,
-						0
-					],
-					[
-						114000,
-						2,
-						0
-					],
-					[
-						114166.666666667,
-						0,
-						0
-					],
-					[
-						114500,
-						1,
-						0
-					],
-					[
-						114500,
-						3,
-						0
-					],
-					[
-						114500,
-						2,
-						750
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						115333.333333333,
-						1,
-						291.666666666667
-					],
-					[
-						115666.666666667,
-						0,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						116000,
-						2,
-						583.333333333333
-					],
-					[
-						116666.666666667,
-						3,
-						250
-					],
-					[
-						117166.666666667,
-						3,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						117333.333333333,
-						1,
-						0
-					],
-					[
-						117500,
-						1,
-						0
-					],
-					[
-						117666.666666667,
-						2,
-						0
-					],
-					[
-						117833.333333333,
-						0,
-						0
-					],
-					[
-						118000,
-						3,
-						0
-					],
-					[
-						118000,
-						1,
-						0
-					],
-					[
-						118166.666666667,
-						2,
-						0
-					],
-					[
-						118500,
-						0,
-						208.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						118833.333333333,
-						2,
-						250
-					],
-					[
-						119166.666666667,
-						1,
-						416.666666666667
-					],
-					[
-						119666.666666667,
-						3,
-						250
-					],
-					[
-						119166.666666667,
-						0,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						120000,
-						2,
-						0
-					],
-					[
-						120166.666666667,
-						2,
-						250
-					],
-					[
-						120500,
-						0,
-						0
-					],
-					[
-						120666.666666667,
-						3,
-						250
-					],
-					[
-						121000,
-						1,
-						0
-					],
-					[
-						120000,
-						4,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						121500,
-						1,
-						0
-					],
-					[
-						121666.666666667,
-						0,
-						0
-					],
-					[
-						121750,
-						2,
-						0
-					],
-					[
-						121833.333333333,
-						3,
-						0
-					],
-					[
-						122000,
-						1,
-						250
-					],
-					[
-						122333.333333333,
-						2,
-						250
-					],
-					[
-						121333.333333333,
-						5,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						122666.666666667,
-						0,
-						250
-					],
-					[
-						123000,
-						3,
-						0
-					],
-					[
-						123166.666666667,
-						1,
-						250
-					],
-					[
-						123500,
-						2,
-						250
-					],
-					[
-						123833.333333333,
-						0,
-						0
-					],
-					[
-						122666.666666667,
-						7,
-						1125
-					],
-					[
-						122666.666666667,
-						6,
-						166.666666666667
-					],
-					[
-						123833.333333333,
-						5,
-						125
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						124000,
-						3,
-						0
-					],
-					[
-						124000,
-						1,
-						0
-					],
-					[
-						124166.666666667,
-						2,
-						250
-					],
-					[
-						124500,
-						0,
-						416.666666666667
-					],
-					[
-						125000,
-						2,
-						250
-					],
-					[
-						124000,
-						6,
-						83.3333333333333
-					],
-					[
-						124166.666666667,
-						4,
-						750
-					],
-					[
-						125000,
-						5,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						125333.333333333,
-						0,
-						0
-					],
-					[
-						125500,
-						2,
-						208.333333333333
-					],
-					[
-						125833.333333333,
-						3,
-						0
-					],
-					[
-						126000,
-						1,
-						250
-					],
-					[
-						126333.333333333,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						126833.333333333,
-						2,
-						0
-					],
-					[
-						127000,
-						1,
-						0
-					],
-					[
-						127083.333333333,
-						3,
-						0
-					],
-					[
-						127166.666666666,
-						2,
-						0
-					],
-					[
-						127333.333333333,
-						0,
-						250
-					],
-					[
-						127666.666666666,
-						3,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						128000,
-						1,
-						208.333333333333
-					],
-					[
-						128333.333333333,
-						2,
-						0
-					],
-					[
-						128500,
-						0,
-						250
-					],
-					[
-						128833.333333333,
-						3,
-						208.333333333333
-					],
-					[
-						129166.666666666,
-						2,
-						166.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						129500,
-						1,
-						208.333333333333
-					],
-					[
-						129833.333333333,
-						3,
-						416.666666666667
-					],
-					[
-						129833.333333333,
-						2,
-						0
-					],
-					[
-						130333.333333333,
-						0,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						130833.333333333,
-						1,
-						0
-					],
-					[
-						131000,
-						0,
-						0
-					],
-					[
-						131166.666666666,
-						1,
-						0
-					],
-					[
-						131333.333333333,
-						3,
-						208.333333333333
-					],
-					[
-						131250,
-						2,
-						0
-					],
-					[
-						131666.666666666,
-						1,
-						0
-					],
-					[
-						131750,
-						0,
-						0
-					],
-					[
-						131833.333333333,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						132166.666666666,
-						3,
-						208.333333333333
-					],
-					[
-						132500,
-						1,
-						250
-					],
-					[
-						132166.666666666,
-						0,
-						0
-					],
-					[
-						132833.333333333,
-						2,
-						0
-					],
-					[
-						133000,
-						0,
-						0
-					],
-					[
-						133166.666666666,
-						3,
-						0
-					],
-					[
-						133166.666666666,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						133500,
-						2,
-						0
-					],
-					[
-						133666.666666667,
-						0,
-						0
-					],
-					[
-						133750,
-						3,
-						0
-					],
-					[
-						133833.333333333,
-						1,
-						250
-					],
-					[
-						134166.666666667,
-						2,
-						0
-					],
-					[
-						134250,
-						3,
-						0
-					],
-					[
-						134333.333333333,
-						0,
-						0
-					],
-					[
-						134500,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						134666.666666667,
-						3,
-						0
-					],
-					[
-						134750,
-						1,
-						0
-					],
-					[
-						134833.333333333,
-						2,
-						0
-					],
-					[
-						135000,
-						0,
-						0
-					],
-					[
-						135333.333333333,
-						3,
-						208.333333333333
-					],
-					[
-						135666.666666667,
-						1,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						136000,
-						2,
-						916.666666666667
-					],
-					[
-						137000,
-						0,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						138000,
-						2,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						138666.666666667,
-						3,
-						875
-					],
-					[
-						139666.666666667,
-						1,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						140666.666666667,
-						2,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						141333.333333333,
-						4,
-						1250
-					],
-					[
-						141333.333333333,
-						5,
-						0
-					],
-					[
-						141333.333333333,
-						3,
-						0
-					],
-					[
-						141500,
-						1,
-						0
-					],
-					[
-						141666.666666667,
-						2,
-						0
-					],
-					[
-						141833.333333333,
-						1,
-						0
-					],
-					[
-						142000,
-						3,
-						0
-					],
-					[
-						142083.333333333,
-						1,
-						0
-					],
-					[
-						142166.666666667,
-						2,
-						0
-					],
-					[
-						142333.333333333,
-						0,
-						0
-					],
-					[
-						142500,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						142666.666666667,
-						7,
-						583.333333333333
-					],
-					[
-						143333.333333333,
-						5,
-						583.333333333333
-					],
-					[
-						142833.333333333,
-						3,
-						0
-					],
-					[
-						142916.666666667,
-						0,
-						0
-					],
-					[
-						143000,
-						2,
-						0
-					],
-					[
-						143166.666666667,
-						1,
-						0
-					],
-					[
-						143333.333333333,
-						3,
-						0
-					],
-					[
-						143500,
-						1,
-						0
-					],
-					[
-						143666.666666667,
-						2,
-						0
-					],
-					[
-						143750,
-						0,
-						0
-					],
-					[
-						143833.333333333,
-						1,
-						0
-					],
-					[
-						143833.333333333,
-						3,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						144000,
-						4,
-						0
-					],
-					[
-						144000,
-						7,
-						0
-					],
-					[
-						144000,
-						6,
-						916.666666666667
-					],
-					[
-						145000,
-						5,
-						250
-					],
-					[
-						144000,
-						2,
-						0
-					],
-					[
-						144166.666666667,
-						3,
-						0
-					],
-					[
-						144333.333333333,
-						1,
-						0
-					],
-					[
-						144500,
-						0,
-						0
-					],
-					[
-						144666.666666667,
-						0,
-						0
-					],
-					[
-						144750,
-						2,
-						0
-					],
-					[
-						144833.333333333,
-						1,
-						0
-					],
-					[
-						144916.666666667,
-						3,
-						0
-					],
-					[
-						145000,
-						0,
-						0
-					],
-					[
-						145166.666666667,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						145333.333333333,
-						4,
-						1250
-					],
-					[
-						145333.333333333,
-						1,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						146666.666666667,
-						7,
-						916.666666666667
-					],
-					[
-						146666.666666667,
-						6,
-						0
-					],
-					[
-						147666.666666667,
-						5,
-						916.666666666667
-					],
-					[
-						146666.666666667,
-						2,
-						0
-					],
-					[
-						146750,
-						3,
-						0
-					],
-					[
-						146833.333333333,
-						0,
-						0
-					],
-					[
-						147166.666666667,
-						2,
-						250
-					],
-					[
-						147500,
-						1,
-						0
-					],
-					[
-						147583.333333333,
-						0,
-						0
-					],
-					[
-						147666.666666667,
-						3,
-						0
-					],
-					[
-						147833.333333333,
-						1,
-						0
-					],
-					[
-						147833.333333333,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						148666.666666667,
-						4,
-						291.666666666667
-					],
-					[
-						149000,
-						5,
-						250
-					],
-					[
-						148166.666666667,
-						0,
-						0
-					],
-					[
-						148333.333333333,
-						1,
-						0
-					],
-					[
-						148500,
-						2,
-						0
-					],
-					[
-						148666.666666667,
-						1,
-						250
-					],
-					[
-						149000,
-						3,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						149333.333333333,
-						6,
-						1250
-					],
-					[
-						149333.333333333,
-						1,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						150666.666666667,
-						4,
-						1250
-					],
-					[
-						150666.666666667,
-						2,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						152000,
-						4,
-						1250
-					],
-					[
-						152000,
-						5,
-						0
-					],
-					[
-						152000,
-						3,
-						0
-					],
-					[
-						152166.666666667,
-						1,
-						0
-					],
-					[
-						152333.333333333,
-						2,
-						0
-					],
-					[
-						152500,
-						1,
-						0
-					],
-					[
-						152666.666666667,
-						3,
-						0
-					],
-					[
-						153000,
-						0,
-						0
-					],
-					[
-						153166.666666667,
-						1,
-						0
-					],
-					[
-						152833.333333333,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						153333.333333333,
-						7,
-						583.333333333333
-					],
-					[
-						154000,
-						5,
-						583.333333333333
-					],
-					[
-						153500,
-						3,
-						0
-					],
-					[
-						153583.333333333,
-						0,
-						0
-					],
-					[
-						153666.666666667,
-						2,
-						0
-					],
-					[
-						153833.333333333,
-						1,
-						0
-					],
-					[
-						154000,
-						3,
-						0
-					],
-					[
-						154166.666666667,
-						1,
-						0
-					],
-					[
-						154333.333333333,
-						2,
-						0
-					],
-					[
-						154416.666666667,
-						0,
-						0
-					],
-					[
-						154500,
-						1,
-						0
-					],
-					[
-						154500,
-						3,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						154666.666666667,
-						4,
-						0
-					],
-					[
-						154666.666666667,
-						7,
-						0
-					],
-					[
-						154666.666666667,
-						6,
-						916.666666666667
-					],
-					[
-						155666.666666667,
-						5,
-						250
-					],
-					[
-						154666.666666667,
-						2,
-						0
-					],
-					[
-						154833.333333333,
-						3,
-						0
-					],
-					[
-						155000,
-						1,
-						0
-					],
-					[
-						155166.666666667,
-						0,
-						0
-					],
-					[
-						155416.666666667,
-						2,
-						0
-					],
-					[
-						155500,
-						1,
-						0
-					],
-					[
-						155583.333333333,
-						3,
-						0
-					],
-					[
-						155666.666666667,
-						0,
-						0
-					],
-					[
-						155833.333333333,
-						2,
-						0
-					],
-					[
-						155333.333333333,
-						3,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						156000,
-						4,
-						1250
-					],
-					[
-						156000,
-						1,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						157333.333333333,
-						7,
-						916.666666666667
-					],
-					[
-						157333.333333333,
-						6,
-						0
-					],
-					[
-						158333.333333333,
-						5,
-						916.666666666667
-					],
-					[
-						157333.333333333,
-						2,
-						0
-					],
-					[
-						157416.666666667,
-						3,
-						0
-					],
-					[
-						157500,
-						0,
-						0
-					],
-					[
-						157833.333333333,
-						2,
-						250
-					],
-					[
-						158166.666666667,
-						1,
-						0
-					],
-					[
-						158250,
-						0,
-						0
-					],
-					[
-						158333.333333333,
-						3,
-						0
-					],
-					[
-						158500,
-						1,
-						0
-					],
-					[
-						158500,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						158833.333333333,
-						0,
-						0
-					],
-					[
-						159000,
-						1,
-						0
-					],
-					[
-						159166.666666667,
-						2,
-						0
-					],
-					[
-						159333.333333333,
-						1,
-						250
-					],
-					[
-						159666.666666667,
-						3,
-						250
-					],
-					[
-						159333.333333333,
-						4,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						160000,
-						6,
-						583.333333333333
-					],
-					[
-						160000,
-						1,
-						1250
-					],
-					[
-						160666.666666667,
-						4,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						161333.333333333,
-						6,
-						0
-					],
-					[
-						161500,
-						6,
-						0
-					],
-					[
-						161666.666666667,
-						4,
-						0
-					],
-					[
-						161833.333333333,
-						6,
-						0
-					],
-					[
-						161333.333333333,
-						3,
-						0
-					],
-					[
-						161500,
-						3,
-						0
-					],
-					[
-						161666.666666667,
-						2,
-						0
-					],
-					[
-						161833.333333333,
-						3,
-						0
-					],
-					[
-						162000,
-						1,
-						250
-					],
-					[
-						162333.333333333,
-						2,
-						0
-					],
-					[
-						162500,
-						0,
-						0
-					],
-					[
-						162500,
-						3,
-						0
-					],
-					[
-						162000,
-						7,
-						250
-					],
-					[
-						162333.333333333,
-						5,
-						0
-					],
-					[
-						162500,
-						6,
-						0
-					],
-					[
-						162500,
-						4,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						162833.333333333,
-						1,
-						0
-					],
-					[
-						163000,
-						3,
-						0
-					],
-					[
-						163166.666666667,
-						1,
-						0
-					],
-					[
-						163333.333333333,
-						2,
-						0
-					],
-					[
-						163666.666666667,
-						0,
-						0
-					],
-					[
-						163833.333333333,
-						3,
-						0
-					],
-					[
-						162666.666666667,
-						5,
-						0
-					],
-					[
-						162833.333333333,
-						5,
-						0
-					],
-					[
-						163000,
-						4,
-						0
-					],
-					[
-						163083.333333333,
-						5,
-						0
-					],
-					[
-						163166.666666667,
-						7,
-						0
-					],
-					[
-						163333.333333333,
-						5,
-						0
-					],
-					[
-						163500,
-						6,
-						0
-					],
-					[
-						163666.666666667,
-						4,
-						0
-					],
-					[
-						163833.333333333,
-						6,
-						0
-					],
-					[
-						163833.333333333,
-						7,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						164166.666666667,
-						2,
-						0
-					],
-					[
-						164333.333333333,
-						0,
-						0
-					],
-					[
-						164666.666666667,
-						2,
-						250
-					],
-					[
-						164666.666666667,
-						3,
-						0
-					],
-					[
-						165000,
-						1,
-						250
-					],
-					[
-						164000,
-						0,
-						0
-					],
-					[
-						164000,
-						5,
-						0
-					],
-					[
-						164166.666666667,
-						5,
-						0
-					],
-					[
-						164333.333333333,
-						4,
-						0
-					],
-					[
-						164416.666666667,
-						7,
-						0
-					],
-					[
-						164500,
-						5,
-						0
-					],
-					[
-						164666.666666667,
-						5,
-						0
-					],
-					[
-						164833.333333333,
-						5,
-						0
-					],
-					[
-						165000,
-						7,
-						0
-					],
-					[
-						165166.666666667,
-						6,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						165500,
-						1,
-						0
-					],
-					[
-						165666.666666667,
-						0,
-						0
-					],
-					[
-						165833.333333333,
-						3,
-						0
-					],
-					[
-						166000,
-						1,
-						0
-					],
-					[
-						166333.333333333,
-						2,
-						916.666666666667
-					],
-					[
-						166333.333333333,
-						3,
-						0
-					],
-					[
-						165333.333333333,
-						4,
-						0
-					],
-					[
-						165500,
-						4,
-						0
-					],
-					[
-						165666.666666667,
-						5,
-						0
-					],
-					[
-						165750,
-						7,
-						0
-					],
-					[
-						165833.333333333,
-						4,
-						0
-					],
-					[
-						166000,
-						4,
-						0
-					],
-					[
-						166166.666666667,
-						5,
-						0
-					],
-					[
-						166333.333333333,
-						6,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						167333.333333333,
-						4,
-						583.333333333333
-					],
-					[
-						167333.333333333,
-						0,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						168000,
-						1,
-						916.666666666667
-					],
-					[
-						169000,
-						3,
-						916.666666666667
-					],
-					[
-						168000,
-						7,
-						916.666666666667
-					],
-					[
-						169000,
-						5,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						170000,
-						2,
-						250
-					],
-					[
-						170333.333333333,
-						0,
-						0
-					],
-					[
-						170500,
-						2,
-						0
-					],
-					[
-						170000,
-						4,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						170666.666666667,
-						3,
-						916.666666666667
-					],
-					[
-						171666.666666667,
-						1,
-						0
-					],
-					[
-						171833.333333333,
-						2,
-						0
-					],
-					[
-						170666.666666667,
-						5,
-						916.666666666667
-					],
-					[
-						171666.666666667,
-						6,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						172000,
-						1,
-						0
-					],
-					[
-						172333.333333333,
-						1,
-						0
-					],
-					[
-						172500,
-						3,
-						0
-					],
-					[
-						172666.666666667,
-						0,
-						583.333333333333
-					],
-					[
-						172666.666666667,
-						4,
-						583.333333333333
-					],
-					[
-						173000,
-						5,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						173500,
-						1,
-						0
-					],
-					[
-						173666.666666667,
-						3,
-						0
-					],
-					[
-						173833.333333333,
-						1,
-						0
-					],
-					[
-						174000,
-						2,
-						0
-					],
-					[
-						174333.333333333,
-						0,
-						0
-					],
-					[
-						174500,
-						3,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						174833.333333333,
-						2,
-						0
-					],
-					[
-						175000,
-						0,
-						0
-					],
-					[
-						175333.333333333,
-						2,
-						250
-					],
-					[
-						175333.333333333,
-						3,
-						0
-					],
-					[
-						175666.666666667,
-						1,
-						250
-					],
-					[
-						174666.666666667,
-						0,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						176166.666666667,
-						1,
-						0
-					],
-					[
-						176333.333333333,
-						0,
-						0
-					],
-					[
-						176500,
-						3,
-						0
-					],
-					[
-						176666.666666667,
-						1,
-						0
-					],
-					[
-						177000,
-						2,
-						0
-					],
-					[
-						177166.666666667,
-						2,
-						0
-					],
-					[
-						176166.666666667,
-						4,
-						0
-					],
-					[
-						176333.333333333,
-						5,
-						0
-					],
-					[
-						176500,
-						4,
-						0
-					],
-					[
-						176583.333333333,
-						7,
-						0
-					],
-					[
-						176666.666666667,
-						6,
-						250
-					],
-					[
-						177000,
-						4,
-						0
-					],
-					[
-						177166.666666667,
-						5,
-						0
-					],
-					[
-						177250,
-						4,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						177333.333333333,
-						6,
-						0
-					],
-					[
-						177500,
-						5,
-						0
-					],
-					[
-						177666.666666667,
-						7,
-						0
-					],
-					[
-						177833.333333333,
-						5,
-						0
-					],
-					[
-						177916.666666667,
-						4,
-						0
-					],
-					[
-						178000,
-						6,
-						0
-					],
-					[
-						178166.666666667,
-						5,
-						0
-					],
-					[
-						178500,
-						6,
-						1083.33333333333
-					],
-					[
-						177333.333333333,
-						0,
-						0
-					],
-					[
-						177500,
-						3,
-						0
-					],
-					[
-						177666.666666667,
-						0,
-						0
-					],
-					[
-						177833.333333333,
-						1,
-						0
-					],
-					[
-						178000,
-						2,
-						250
-					],
-					[
-						178333.333333333,
-						3,
-						250
-					],
-					[
-						178333.333333333,
-						1,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						179666.666666667,
-						0,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						180000,
-						3,
-						0
-					],
-					[
-						180083.333333334,
-						1,
-						0
-					],
-					[
-						180166.666666667,
-						3,
-						0
-					],
-					[
-						180250,
-						2,
-						0
-					],
-					[
-						180333.333333334,
-						3,
-						0
-					],
-					[
-						180416.666666667,
-						0,
-						0
-					],
-					[
-						180500,
-						3,
-						0
-					],
-					[
-						180583.333333334,
-						1,
-						0
-					],
-					[
-						180666.666666667,
-						2,
-						0
-					],
-					[
-						180833.333333334,
-						0,
-						0
-					],
-					[
-						181000,
-						1,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						181333.333333334,
-						3,
-						0
-					],
-					[
-						181416.666666667,
-						1,
-						0
-					],
-					[
-						181500,
-						3,
-						0
-					],
-					[
-						181583.333333334,
-						2,
-						0
-					],
-					[
-						181666.666666667,
-						3,
-						0
-					],
-					[
-						181750,
-						0,
-						0
-					],
-					[
-						181833.333333334,
-						3,
-						0
-					],
-					[
-						181916.666666667,
-						1,
-						0
-					],
-					[
-						182333.333333334,
-						1,
-						250
-					],
-					[
-						182000,
-						2,
-						250
-					],
-					[
-						181333.333333334,
-						4,
-						0
-					],
-					[
-						181416.666666667,
-						7,
-						0
-					],
-					[
-						181500,
-						4,
-						0
-					],
-					[
-						181583.333333334,
-						5,
-						0
-					],
-					[
-						181666.666666667,
-						4,
-						0
-					],
-					[
-						181750,
-						6,
-						0
-					],
-					[
-						181833.333333334,
-						4,
-						0
-					],
-					[
-						181916.666666667,
-						5,
-						0
-					],
-					[
-						182000,
-						7,
-						250
-					],
-					[
-						182333.333333334,
-						5,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						182666.666666667,
-						7,
-						0
-					],
-					[
-						182750,
-						5,
-						0
-					],
-					[
-						182833.333333334,
-						4,
-						0
-					],
-					[
-						182916.666666667,
-						5,
-						0
-					],
-					[
-						183000,
-						6,
-						0
-					],
-					[
-						183083.333333334,
-						5,
-						0
-					],
-					[
-						183166.666666667,
-						7,
-						0
-					],
-					[
-						183250,
-						5,
-						0
-					],
-					[
-						183333.333333334,
-						6,
-						250
-					],
-					[
-						183666.666666667,
-						4,
-						250
-					],
-					[
-						182666.666666667,
-						3,
-						0
-					],
-					[
-						182750,
-						0,
-						0
-					],
-					[
-						182833.333333334,
-						3,
-						0
-					],
-					[
-						182916.666666667,
-						1,
-						0
-					],
-					[
-						183000,
-						3,
-						0
-					],
-					[
-						183083.333333334,
-						2,
-						0
-					],
-					[
-						183166.666666667,
-						3,
-						0
-					],
-					[
-						183250,
-						1,
-						0
-					],
-					[
-						183333.333333334,
-						0,
-						250
-					],
-					[
-						183666.666666667,
-						3,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						184000,
-						1,
-						2083.33333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						185333.333333334,
-						0,
-						0
-					],
-					[
-						185500,
-						1,
-						0
-					],
-					[
-						185666.666666667,
-						2,
-						0
-					],
-					[
-						185833.333333334,
-						1,
-						0
-					],
-					[
-						185833.333333334,
-						0,
-						0
-					],
-					[
-						186000,
-						3,
-						0
-					],
-					[
-						186083.333333334,
-						0,
-						0
-					],
-					[
-						186166.666666667,
-						2,
-						0
-					],
-					[
-						186333.333333334,
-						1,
-						0
-					],
-					[
-						186500,
-						3,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						187333.333333334,
-						4,
-						583.333333333333
-					],
-					[
-						187500,
-						3,
-						0
-					],
-					[
-						187666.666666667,
-						2,
-						250
-					],
-					[
-						186833.333333334,
-						1,
-						416.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						188000,
-						5,
-						583.333333333333
-					],
-					[
-						188666.666666667,
-						6,
-						250
-					],
-					[
-						189000,
-						7,
-						250
-					],
-					[
-						188000,
-						0,
-						250
-					],
-					[
-						188333.333333334,
-						2,
-						250
-					],
-					[
-						188333.333333334,
-						1,
-						0
-					],
-					[
-						188666.666666667,
-						3,
-						250
-					],
-					[
-						189000,
-						1,
-						416.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						189333.333333334,
-						5,
-						1750
-					],
-					[
-						190000,
-						3,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						190833.333333334,
-						0,
-						0
-					],
-					[
-						191000,
-						3,
-						0
-					],
-					[
-						191166.666666667,
-						1,
-						0
-					],
-					[
-						191333.333333334,
-						2,
-						0
-					],
-					[
-						191416.666666667,
-						0,
-						0
-					],
-					[
-						191500,
-						1,
-						0
-					],
-					[
-						191666.666666667,
-						3,
-						0
-					],
-					[
-						191833.333333334,
-						2,
-						250
-					],
-					[
-						191833.333333334,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						192166.666666667,
-						0,
-						250
-					],
-					[
-						192833.333333334,
-						3,
-						0
-					],
-					[
-						193000,
-						1,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						193333.333333334,
-						2,
-						250
-					],
-					[
-						193666.666666667,
-						0,
-						250
-					],
-					[
-						194000,
-						3,
-						250
-					],
-					[
-						194333.333333334,
-						2,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						194666.666666667,
-						1,
-						0
-					],
-					[
-						194833.333333334,
-						0,
-						0
-					],
-					[
-						195000,
-						3,
-						0
-					],
-					[
-						195083.333333334,
-						1,
-						0
-					],
-					[
-						195166.666666667,
-						2,
-						0
-					],
-					[
-						195333.333333334,
-						0,
-						0
-					],
-					[
-						195500,
-						2,
-						0
-					],
-					[
-						195666.666666667,
-						1,
-						0
-					],
-					[
-						195833.333333334,
-						2,
-						0
-					],
-					[
-						194666.666666667,
-						4,
-						1166.66666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						196000,
-						0,
-						0
-					],
-					[
-						196166.666666667,
-						1,
-						0
-					],
-					[
-						196333.333333334,
-						2,
-						0
-					],
-					[
-						196500,
-						1,
-						0
-					],
-					[
-						196500,
-						0,
-						0
-					],
-					[
-						196666.666666667,
-						3,
-						0
-					],
-					[
-						196750,
-						0,
-						0
-					],
-					[
-						196833.333333334,
-						2,
-						0
-					],
-					[
-						197000,
-						1,
-						0
-					],
-					[
-						197166.666666667,
-						3,
-						250
-					],
-					[
-						196000,
-						7,
-						0
-					],
-					[
-						196166.666666667,
-						5,
-						0
-					],
-					[
-						196333.333333334,
-						6,
-						0
-					],
-					[
-						196500,
-						5,
-						0
-					],
-					[
-						196666.666666667,
-						4,
-						0
-					],
-					[
-						196750,
-						7,
-						0
-					],
-					[
-						196833.333333334,
-						5,
-						0
-					],
-					[
-						197000,
-						6,
-						0
-					],
-					[
-						197166.666666667,
-						4,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						197500,
-						1,
-						333.333333333333
-					],
-					[
-						198166.666666667,
-						3,
-						0
-					],
-					[
-						198333.333333334,
-						2,
-						250
-					],
-					[
-						197500,
-						7,
-						333.333333333333
-					],
-					[
-						198333.333333334,
-						6,
-						250
-					],
-					[
-						198166.666666667,
-						4,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						199333.333333334,
-						6,
-						250
-					],
-					[
-						199666.666666667,
-						7,
-						416.666666666667
-					],
-					[
-						198666.666666667,
-						0,
-						250
-					],
-					[
-						199000,
-						2,
-						250
-					],
-					[
-						199000,
-						1,
-						0
-					],
-					[
-						199333.333333334,
-						3,
-						250
-					],
-					[
-						199666.666666667,
-						1,
-						250
-					],
-					[
-						199000,
-						4,
-						250
-					],
-					[
-						199000,
-						7,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						200666.666666667,
-						3,
-						1083.33333333333
-					],
-					[
-						200000,
-						0,
-						583.333333333333
-					],
-					[
-						200666.666666667,
-						5,
-						250
-					],
-					[
-						200666.666666667,
-						4,
-						166.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						202000,
-						2,
-						0
-					],
-					[
-						202083.333333334,
-						0,
-						0
-					],
-					[
-						202166.666666667,
-						1,
-						0
-					],
-					[
-						202333.333333334,
-						3,
-						0
-					],
-					[
-						202500,
-						2,
-						250
-					],
-					[
-						202500,
-						1,
-						0
-					],
-					[
-						201500,
-						5,
-						0
-					],
-					[
-						201666.666666667,
-						6,
-						0
-					],
-					[
-						201833.333333334,
-						5,
-						0
-					],
-					[
-						202000,
-						7,
-						0
-					],
-					[
-						202083.333333334,
-						5,
-						0
-					],
-					[
-						202166.666666667,
-						6,
-						0
-					],
-					[
-						202333.333333334,
-						4,
-						0
-					],
-					[
-						202500,
-						7,
-						0
-					],
-					[
-						202500,
-						6,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						202833.333333334,
-						0,
-						250
-					],
-					[
-						203500,
-						3,
-						0
-					],
-					[
-						203666.666666667,
-						1,
-						250
-					],
-					[
-						202833.333333334,
-						5,
-						250
-					],
-					[
-						203666.666666667,
-						7,
-						250
-					],
-					[
-						203500,
-						4,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						204000,
-						2,
-						250
-					],
-					[
-						204333.333333334,
-						0,
-						250
-					],
-					[
-						204666.666666667,
-						3,
-						250
-					],
-					[
-						205000,
-						2,
-						250
-					],
-					[
-						204000,
-						6,
-						250
-					],
-					[
-						204333.333333334,
-						5,
-						250
-					],
-					[
-						204666.666666667,
-						4,
-						250
-					],
-					[
-						205000,
-						6,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						205500,
-						1,
-						0
-					],
-					[
-						205666.666666667,
-						3,
-						0
-					],
-					[
-						205833.333333333,
-						1,
-						0
-					],
-					[
-						206000,
-						2,
-						0
-					],
-					[
-						206333.333333333,
-						0,
-						0
-					],
-					[
-						206416.666666667,
-						1,
-						0
-					],
-					[
-						206500,
-						3,
-						0
-					],
-					[
-						205750,
-						0,
-						0
-					],
-					[
-						205333.333333334,
-						5,
-						1000
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						206666.666666667,
-						1,
-						0
-					],
-					[
-						206833.333333333,
-						2,
-						0
-					],
-					[
-						207000,
-						0,
-						0
-					],
-					[
-						207333.333333333,
-						2,
-						250
-					],
-					[
-						207333.333333333,
-						3,
-						0
-					],
-					[
-						207666.666666667,
-						1,
-						250
-					],
-					[
-						206666.666666667,
-						7,
-						583.333333333333
-					],
-					[
-						207333.333333334,
-						4,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						208166.666666667,
-						1,
-						0
-					],
-					[
-						208333.333333333,
-						0,
-						0
-					],
-					[
-						208416.666666667,
-						2,
-						0
-					],
-					[
-						208500,
-						3,
-						0
-					],
-					[
-						208666.666666667,
-						1,
-						0
-					],
-					[
-						209000,
-						2,
-						0
-					],
-					[
-						209166.666666667,
-						0,
-						0
-					],
-					[
-						208833.333333334,
-						3,
-						0
-					],
-					[
-						208916.666666667,
-						1,
-						0
-					],
-					[
-						209083.333333334,
-						3,
-						0
-					],
-					[
-						209250,
-						1,
-						0
-					],
-					[
-						208000,
-						6,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						209333.333333333,
-						2,
-						0
-					],
-					[
-						209500,
-						1,
-						0
-					],
-					[
-						209666.666666667,
-						3,
-						0
-					],
-					[
-						209833.333333333,
-						3,
-						0
-					],
-					[
-						210000,
-						2,
-						250
-					],
-					[
-						210333.333333334,
-						0,
-						250
-					],
-					[
-						209333.333333334,
-						7,
-						1250
-					],
-					[
-						209333.333333334,
-						5,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						210666.666666667,
-						1,
-						0
-					],
-					[
-						210750,
-						3,
-						0
-					],
-					[
-						210833.333333334,
-						0,
-						0
-					],
-					[
-						210916.666666667,
-						1,
-						0
-					],
-					[
-						211000,
-						2,
-						0
-					],
-					[
-						211166.666666667,
-						3,
-						0
-					],
-					[
-						211333.333333334,
-						1,
-						0
-					],
-					[
-						211500,
-						2,
-						0
-					],
-					[
-						211666.666666667,
-						0,
-						0
-					],
-					[
-						211833.333333334,
-						2,
-						0
-					],
-					[
-						210666.666666667,
-						6,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						212000,
-						1,
-						0
-					],
-					[
-						212083.333333334,
-						0,
-						0
-					],
-					[
-						212166.666666667,
-						3,
-						0
-					],
-					[
-						212250,
-						1,
-						0
-					],
-					[
-						212333.333333334,
-						2,
-						0
-					],
-					[
-						212416.666666667,
-						0,
-						0
-					],
-					[
-						212500,
-						1,
-						0
-					],
-					[
-						212666.666666667,
-						3,
-						0
-					],
-					[
-						212833.333333334,
-						2,
-						0
-					],
-					[
-						213000,
-						0,
-						250
-					],
-					[
-						212000,
-						4,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						213333.333333334,
-						1,
-						0
-					],
-					[
-						213500,
-						1,
-						0
-					],
-					[
-						213666.666666667,
-						2,
-						0
-					],
-					[
-						213833.333333334,
-						3,
-						0
-					],
-					[
-						214000,
-						0,
-						0
-					],
-					[
-						214166.666666667,
-						0,
-						0
-					],
-					[
-						214333.333333334,
-						2,
-						0
-					],
-					[
-						214500,
-						1,
-						0
-					],
-					[
-						213333.333333334,
-						5,
-						250
-					],
-					[
-						213666.666666667,
-						6,
-						0
-					],
-					[
-						213833.333333334,
-						5,
-						0
-					],
-					[
-						214000,
-						7,
-						0
-					],
-					[
-						214083.333333334,
-						4,
-						0
-					],
-					[
-						214166.666666667,
-						6,
-						0
-					],
-					[
-						214333.333333334,
-						5,
-						416.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						214666.666666667,
-						3,
-						250
-					],
-					[
-						215000,
-						2,
-						250
-					],
-					[
-						215333.333333334,
-						0,
-						250
-					],
-					[
-						215666.666666667,
-						1,
-						250
-					],
-					[
-						214833.333333334,
-						6,
-						416.666666666667
-					],
-					[
-						214833.333333334,
-						4,
-						0
-					],
-					[
-						215333.333333334,
-						5,
-						250
-					],
-					[
-						215666.666666667,
-						7,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						216166.666666667,
-						1,
-						0
-					],
-					[
-						216333.333333333,
-						3,
-						0
-					],
-					[
-						216500,
-						1,
-						0
-					],
-					[
-						216666.666666667,
-						2,
-						0
-					],
-					[
-						217000,
-						0,
-						0
-					],
-					[
-						217083.333333333,
-						1,
-						0
-					],
-					[
-						217166.666666667,
-						3,
-						0
-					],
-					[
-						216416.666666667,
-						0,
-						0
-					],
-					[
-						216000,
-						7,
-						250
-					],
-					[
-						216333.333333334,
-						6,
-						250
-					],
-					[
-						216666.666666667,
-						4,
-						250
-					],
-					[
-						217000,
-						5,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						217333.333333333,
-						1,
-						0
-					],
-					[
-						217500,
-						2,
-						0
-					],
-					[
-						217666.666666667,
-						0,
-						0
-					],
-					[
-						218000,
-						2,
-						250
-					],
-					[
-						218000,
-						3,
-						0
-					],
-					[
-						218333.333333333,
-						1,
-						250
-					],
-					[
-						217333.333333334,
-						7,
-						583.333333333333
-					],
-					[
-						218000,
-						4,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						218833.333333333,
-						1,
-						0
-					],
-					[
-						219000,
-						0,
-						0
-					],
-					[
-						219083.333333333,
-						2,
-						0
-					],
-					[
-						219166.666666667,
-						3,
-						0
-					],
-					[
-						219333.333333333,
-						1,
-						0
-					],
-					[
-						219666.666666667,
-						2,
-						0
-					],
-					[
-						219833.333333333,
-						0,
-						0
-					],
-					[
-						219500,
-						3,
-						0
-					],
-					[
-						219583.333333334,
-						1,
-						0
-					],
-					[
-						219750,
-						3,
-						0
-					],
-					[
-						219916.666666667,
-						1,
-						0
-					],
-					[
-						218666.666666667,
-						6,
-						1250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						220000,
-						2,
-						0
-					],
-					[
-						220166.666666667,
-						1,
-						0
-					],
-					[
-						220333.333333333,
-						3,
-						0
-					],
-					[
-						220500,
-						3,
-						0
-					],
-					[
-						220666.666666667,
-						2,
-						250
-					],
-					[
-						221000,
-						0,
-						250
-					],
-					[
-						220000,
-						7,
-						1000
-					],
-					[
-						220000,
-						5,
-						0
-					],
-					[
-						221000,
-						4,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						221333.333333334,
-						1,
-						0
-					],
-					[
-						221416.666666667,
-						3,
-						0
-					],
-					[
-						221500,
-						0,
-						0
-					],
-					[
-						221583.333333334,
-						1,
-						0
-					],
-					[
-						221666.666666667,
-						2,
-						0
-					],
-					[
-						221833.333333334,
-						3,
-						0
-					],
-					[
-						222000,
-						1,
-						0
-					],
-					[
-						222166.666666667,
-						2,
-						0
-					],
-					[
-						222333.333333334,
-						0,
-						0
-					],
-					[
-						222500,
-						2,
-						0
-					],
-					[
-						221333.333333334,
-						6,
-						416.666666666667
-					],
-					[
-						221833.333333334,
-						7,
-						416.666666666667
-					],
-					[
-						222333.333333334,
-						5,
-						666.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						222666.666666667,
-						1,
-						0
-					],
-					[
-						222750,
-						0,
-						0
-					],
-					[
-						222833.333333334,
-						3,
-						0
-					],
-					[
-						222916.666666667,
-						1,
-						0
-					],
-					[
-						223000,
-						2,
-						0
-					],
-					[
-						223083.333333334,
-						0,
-						0
-					],
-					[
-						223166.666666667,
-						1,
-						0
-					],
-					[
-						223333.333333334,
-						3,
-						0
-					],
-					[
-						223500,
-						2,
-						0
-					],
-					[
-						223666.666666667,
-						0,
-						250
-					],
-					[
-						223166.666666667,
-						5,
-						0
-					],
-					[
-						223333.333333334,
-						4,
-						0
-					],
-					[
-						223500,
-						7,
-						0
-					],
-					[
-						223750,
-						4,
-						0
-					],
-					[
-						223666.666666667,
-						7,
-						0
-					],
-					[
-						223833.333333334,
-						5,
-						0
-					],
-					[
-						223916.666666667,
-						7,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						224000,
-						1,
-						0
-					],
-					[
-						224166.666666667,
-						1,
-						0
-					],
-					[
-						224333.333333334,
-						2,
-						0
-					],
-					[
-						224500,
-						3,
-						0
-					],
-					[
-						224666.666666667,
-						0,
-						0
-					],
-					[
-						224833.333333334,
-						0,
-						0
-					],
-					[
-						225000,
-						2,
-						0
-					],
-					[
-						225166.666666667,
-						1,
-						0
-					],
-					[
-						224000,
-						6,
-						0
-					],
-					[
-						224166.666666667,
-						5,
-						0
-					],
-					[
-						224250,
-						4,
-						166.666666666667
-					],
-					[
-						224500,
-						5,
-						0
-					],
-					[
-						224583.333333334,
-						7,
-						0
-					],
-					[
-						224666.666666667,
-						6,
-						0
-					],
-					[
-						224750,
-						4,
-						0
-					],
-					[
-						224833.333333334,
-						6,
-						0
-					],
-					[
-						224916.666666667,
-						5,
-						0
-					],
-					[
-						225000,
-						7,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						225333.333333334,
-						3,
-						250
-					],
-					[
-						225666.666666667,
-						2,
-						250
-					],
-					[
-						226000,
-						0,
-						250
-					],
-					[
-						226333.333333334,
-						1,
-						250
-					],
-					[
-						225333.333333334,
-						4,
-						0
-					],
-					[
-						225416.666666667,
-						6,
-						0
-					],
-					[
-						225500,
-						5,
-						166.666666666667
-					],
-					[
-						225750,
-						7,
-						166.666666666667
-					],
-					[
-						226000,
-						6,
-						250
-					],
-					[
-						226333.333333334,
-						4,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						226666.666666667,
-						1,
-						1250
-					],
-					[
-						226666.666666667,
-						4,
-						250
-					],
-					[
-						227000.000000001,
-						7,
-						0
-					],
-					[
-						227500.000000001,
-						7,
-						0
-					],
-					[
-						227666.666666667,
-						5,
-						0
-					],
-					[
-						227833.333333334,
-						7,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						228000.000000001,
-						0,
-						250
-					],
-					[
-						228333.333333334,
-						3,
-						0
-					],
-					[
-						228833.333333334,
-						3,
-						0
-					],
-					[
-						229000.000000001,
-						1,
-						0
-					],
-					[
-						229166.666666667,
-						3,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						229333.333333334,
-						1,
-						250
-					],
-					[
-						229666.666666667,
-						2,
-						250
-					],
-					[
-						230166.666666667,
-						2,
-						0
-					],
-					[
-						230333.333333334,
-						0,
-						0
-					],
-					[
-						230500.000000001,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						230666.666666667,
-						3,
-						250
-					],
-					[
-						231000.000000001,
-						1,
-						250
-					],
-					[
-						231333.333333334,
-						2,
-						250
-					],
-					[
-						231666.666666667,
-						0,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						232000.000000001,
-						3,
-						1916.66666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						234000.000000001,
-						1,
-						0
-					],
-					[
-						234166.666666667,
-						3,
-						0
-					],
-					[
-						234333.333333334,
-						1,
-						0
-					],
-					[
-						234500.000000001,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						234666.666666667,
-						0,
-						1250
-					],
-					[
-						234666.666666667,
-						1,
-						333.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						236000.000000001,
-						3,
-						583.333333333333
-					],
-					[
-						236666.666666667,
-						2,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						237333.333333334,
-						5,
-						1833.33333333333
-					],
-					[
-						237333.333333334,
-						0,
-						250
-					],
-					[
-						237666.666666667,
-						3,
-						0
-					],
-					[
-						238166.666666667,
-						3,
-						0
-					],
-					[
-						238333.333333334,
-						1,
-						0
-					],
-					[
-						238500,
-						3,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						238666.666666667,
-						0,
-						250
-					],
-					[
-						239000.000000001,
-						3,
-						0
-					],
-					[
-						239500.000000001,
-						3,
-						0
-					],
-					[
-						239666.666666667,
-						1,
-						0
-					],
-					[
-						239833.333333334,
-						3,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						240000.000000001,
-						1,
-						250
-					],
-					[
-						240333.333333334,
-						2,
-						250
-					],
-					[
-						240833.333333334,
-						2,
-						0
-					],
-					[
-						241000.000000001,
-						0,
-						0
-					],
-					[
-						241166.666666667,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						241333.333333334,
-						3,
-						250
-					],
-					[
-						241666.666666667,
-						1,
-						250
-					],
-					[
-						242000.000000001,
-						2,
-						250
-					],
-					[
-						242333.333333334,
-						0,
-						250
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						242666.666666667,
-						3,
-						1916.66666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						244666.666666667,
-						1,
-						0
-					],
-					[
-						244833.333333334,
-						3,
-						0
-					],
-					[
-						245000.000000001,
-						1,
-						0
-					],
-					[
-						245166.666666667,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						245333.333333334,
-						0,
-						1250
-					],
-					[
-						245333.333333334,
-						1,
-						333.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						246666.666666667,
-						3,
-						583.333333333333
-					],
-					[
-						247333.333333334,
-						1,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						248000.000000001,
-						6,
-						1916.66666666667
-					],
-					[
-						248000,
-						6,
-						750
-					],
-					[
-						248000,
-						6,
-						750
-					],
-					[
-						248000,
-						1,
-						416.666666666667
-					],
-					[
-						249000,
-						2,
-						916.666666666667
-					],
-					[
-						248500.000000001,
-						3,
-						416.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						250000,
-						0,
-						250
-					],
-					[
-						250333.333333333,
-						2,
-						0
-					],
-					[
-						250500,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						250666.666666667,
-						3,
-						416.666666666667
-					],
-					[
-						251166.666666667,
-						1,
-						333.333333333333
-					],
-					[
-						251666.666666667,
-						2,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						252666.666666667,
-						1,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						253333.333333333,
-						0,
-						916.666666666667
-					],
-					[
-						254333.333333333,
-						3,
-						583.333333333333
-					],
-					[
-						254333.333333333,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						255000,
-						1,
-						0
-					],
-					[
-						255333.333333333,
-						1,
-						0
-					],
-					[
-						255500,
-						1,
-						0
-					],
-					[
-						255666.666666667,
-						1,
-						0
-					],
-					[
-						255750,
-						3,
-						0
-					],
-					[
-						255833.333333333,
-						0,
-						0
-					],
-					[
-						255916.666666667,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						256000,
-						2,
-						916.666666666667
-					],
-					[
-						257000,
-						3,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						258000.000000001,
-						1,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						258666.666666667,
-						1,
-						250
-					],
-					[
-						259166.666666667,
-						3,
-						416.666666666667
-					],
-					[
-						259000,
-						0,
-						0
-					],
-					[
-						259666.666666667,
-						2,
-						250
-					],
-					[
-						258666.666666667,
-						1,
-						250
-					],
-					[
-						259666.666666667,
-						2,
-						916.666666666667
-					],
-					[
-						259166.666666667,
-						3,
-						416.666666666667
-					],
-					[
-						258666.666666667,
-						6,
-						2500
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						260666.666666667,
-						0,
-						250
-					],
-					[
-						261000,
-						2,
-						0
-					],
-					[
-						261166.666666667,
-						2,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						261333.333333333,
-						3,
-						250
-					],
-					[
-						261833.333333333,
-						1,
-						416.666666666666
-					],
-					[
-						262333.333333333,
-						2,
-						916.666666666667
-					],
-					[
-						261666.666666667,
-						1,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						263333.333333333,
-						1,
-						583.333333333333
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": true
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						264000,
-						4,
-						916.666666666667
-					],
-					[
-						265000,
-						7,
-						583.333333333333
-					],
-					[
-						265000,
-						6,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						265666.666666667,
-						5,
-						0
-					],
-					[
-						266000,
-						5,
-						0
-					],
-					[
-						266166.666666667,
-						5,
-						0
-					],
-					[
-						266333.333333333,
-						5,
-						0
-					],
-					[
-						266416.666666667,
-						7,
-						0
-					],
-					[
-						266500,
-						4,
-						0
-					],
-					[
-						266583.333333333,
-						5,
-						0
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						266666.666666667,
-						6,
-						916.666666666667
-					],
-					[
-						267666.666666667,
-						7,
-						916.666666666667
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						268666.666666667,
-						5,
-						583.333333333333,
-						"No Animation"
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [
-					[
-						269333.333333334,
-						4,
-						1666.66666666667,
-						"No Animation"
-					]
-				],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"sectionBeats": 4,
-				"altAnim": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false,
-				"mustHitSection": false
-			},
-			{
-				"sectionBeats": 4,
-				"sectionNotes": [],
-				"typeOfSection": 0,
-				"gfSection": false,
-				"altAnim": false,
-				"mustHitSection": true,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"sectionNotes": [],
-				"typeOfSection": 0,
-				"gfSection": false,
-				"altAnim": false,
-				"mustHitSection": true,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"sectionNotes": [],
-				"typeOfSection": 0,
-				"gfSection": false,
-				"altAnim": false,
-				"mustHitSection": true,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"sectionNotes": [],
-				"typeOfSection": 0,
-				"gfSection": false,
-				"altAnim": false,
-				"mustHitSection": true,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"sectionNotes": [],
-				"typeOfSection": 0,
-				"gfSection": false,
-				"altAnim": false,
-				"mustHitSection": true,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"sectionNotes": [],
-				"typeOfSection": 0,
-				"gfSection": false,
-				"altAnim": false,
-				"mustHitSection": true,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"sectionNotes": [],
-				"typeOfSection": 0,
-				"gfSection": false,
-				"altAnim": false,
-				"mustHitSection": true,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"sectionNotes": [],
-				"typeOfSection": 0,
-				"gfSection": false,
-				"altAnim": false,
-				"mustHitSection": true,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"sectionNotes": [],
-				"typeOfSection": 0,
-				"gfSection": false,
-				"altAnim": false,
-				"mustHitSection": true,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"sectionNotes": [],
-				"typeOfSection": 0,
-				"gfSection": false,
-				"altAnim": false,
-				"mustHitSection": true,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"sectionNotes": [],
-				"typeOfSection": 0,
-				"gfSection": false,
-				"altAnim": false,
-				"mustHitSection": true,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"changeBPM": false,
-				"bpm": 180
-			},
-			{
-				"sectionBeats": 4,
-				"altAnim": false,
-				"mustHitSection": true,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"bpm": 180,
-				"changeBPM": false
-			},
-			{
-				"pixelNoteSection": false,
-				"gfSection": false,
-				"altAnim": false,
-				"typeOfSection": 0,
-				"sectionNotes": [],
-				"bpm": 180,
-				"sectionBeats": 4,
-				"changeBPM": false,
-				"mustHitSection": true
-			}
-		],
-		"gfVersion": "gf",
+		"player2": "salvage",
 		"splashSkin": "noteSplashes",
 		"song": "trapped",
-		"validScore": true,
-		"stage": "trapped",
-		"arrowSkin": "",
 		"needsVoices": true,
-		"speed": 2.5,
-		"bpm": 180
+		"arrowSkin": "",
+		"stage": "trapped",
+		"validScore": true,
+		"bpm": 180,
+		"speed": 2.5
 	}
 }

--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -24,6 +24,8 @@ import flixel.input.keyboard.FlxKey;
 import flixel.addons.display.FlxBackdrop;
 import flixel.addons.display.FlxGridOverlay;
 
+import options.OptionsState;
+
 using StringTools;
 
 class MainMenuState extends MusicBeatState
@@ -77,6 +79,7 @@ class MainMenuState extends MusicBeatState
 		transOut = FlxTransitionableState.defaultTransOut;
 
 		persistentUpdate = persistentDraw = true;
+		OptionsState.onPlayState = false;
 
 		if (FlxG.sound.music.length != 118142) { //weird asf way to do this but err lol?
 			FlxG.sound.playMusic(Paths.music('freakyMenu'),0);

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -212,12 +212,6 @@ class PauseSubState extends MusicBeatSubstate
 					PlayState.instance.paused = true; // For lua
 					PlayState.instance.vocals.volume = 0;
 					MusicBeatState.switchState(new OptionsState());
-					// if(ClientPrefs.pauseMusic != 'None')
-					// {
-					// 	FlxG.sound.playMusic(Paths.music(Paths.formatToSongPath(ClientPrefs.pauseMusic)), pauseMusic.volume);
-					// 	FlxTween.tween(FlxG.sound.music, {volume: 1}, 0.8);
-					// 	FlxG.sound.music.time = pauseMusic.time;
-					// }
 					OptionsState.onPlayState = true;
 				case "exit":
 					if (PlayState.SONG.song.toLowerCase() == 'followed' && FlxG.save.data.firstFollowedExit == null) {

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -976,7 +976,7 @@ class PlayState extends MusicBeatState
 
 		for (i in 0...5)
 		{
-			var star = new FlxSprite(pHPBG.getGraphicMidpoint().x + 172 + ((i - (5/2))*(12*6)),pHPBG.y+pHPBG.height + 9).loadGraphic(Paths.image('pixelHUD/stars'),true,11,10);//ngl this sucks ass but erm lol!
+			var star = new FlxSprite(pHPBG.getGraphicMidpoint().x + 4 + ((i - (5/2))*(12*6)),pHPBG.y+pHPBG.height + 9).loadGraphic(Paths.image('pixelHUD/stars'),true,11,10);//ngl this sucks ass but erm lol!
 			//ill fix these positions later because holy this sucks
 			star.animation.add('still',[0]);
 			star.animation.add('flash',[0,1,2],12);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2199,7 +2199,7 @@ class PlayState extends MusicBeatState
 			for (i in 0...opponentStrums.length) {
 				setOnLuas('defaultOpponentStrumX' + i, opponentStrums.members[i].x);
 				setOnLuas('defaultOpponentStrumY' + i, opponentStrums.members[i].y);
-				//if(ClientPrefs.middleScroll) opponentStrums.members[i].visible = false;
+				if(ClientPrefs.middleScroll) opponentStrums.members[i].visible = false;
 			}
 
 			startedCountdown = true;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -4721,7 +4721,7 @@ class PlayState extends MusicBeatState
 		var boyfriendCamDisplace:Array<Float> = [0.,0.];
 		var dadCamDisplace:Array<Float> = [0.,0.0];
 		var offsets:Array<Float> = [0.,0.];
-		if (isNote && (ClientPrefs.followChars || SONG.song.toLowerCase() == 'restless')){
+		if (isNote && (ClientPrefs.followChars || SONG.song.toLowerCase() == 'restless' || SONG.song.toLowerCase() == 'followed')){
 			if (isCameraOnForcedDad) isDad = true;
 			if (isCameraOnForcedBoyfriend) isDad = false;
 			var char = isDad ? dad : boyfriend;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -4721,7 +4721,7 @@ class PlayState extends MusicBeatState
 		var boyfriendCamDisplace:Array<Float> = [0.,0.];
 		var dadCamDisplace:Array<Float> = [0.,0.0];
 		var offsets:Array<Float> = [0.,0.];
-		if (isNote && ClientPrefs.followChars){
+		if (isNote && (ClientPrefs.followChars || SONG.song.toLowerCase() == 'restless')){
 			if (isCameraOnForcedDad) isDad = true;
 			if (isCameraOnForcedBoyfriend) isDad = false;
 			var char = isDad ? dad : boyfriend;


### PR DESCRIPTION
## This pull request is meant to fix bugs discovered by idkman133 in their [some bugs](https://github.com/FixedData/ourpleV3SourceCodePUBLIC/issues/6) GitHub issue. 
### Below are explanations for each commit I made and how it fixes a bug outlined in the issue.

fixed ourple option bug: `OptionsState.onPlayState` would be set to true when entering `OptionsState` via the `PauseSubState`. When entering the `MainMenuState`, the bool would not be set back to false, leading the `OptionsState` to switch back to  `PlayState` when exiting and causing the [ourple option bug](https://www.youtube.com/watch?v=Sg1PHAFG9-g).

centered pixelStars: The offset for the pixelStars was too big at 172, leading to the stars being off-centered during Watchful. I set the offset to 4. I don't know if it's mathematically centered now, I just eyeballed it.

create exception for restless: When `ClientPrefs.followChars` is turned off, the camera is not centered on Restless. I made an exception for Restless in the function `moveCamera()` so that the player doesn't need `ClientPrefs.followChars` to be true in order for the camera to be centered during Restless.

hide opponentStrums if middleScroll: I uncommented the code for hiding the opponents strums if `ClientPrefs.middleScroll` was true. Why was this commented out? 

fixed stacked long notes in Trapped: Recharted 2 long notes in Trapped that had stacked notes on it.

extend exception for followed: Extends the extension created for Restless to prevent the camera from veering off to the left during Followed when `ClientPrefs.followChars` is turned off.